### PR TITLE
build(windows): MSVC/MinGW presets, windeployqt, and CMake Tools launch

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,49 +2,110 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "▶️ (CMake) Запуск DONTFLOAT - MSVC Debug",
+            "name": "▶️ (CMake) Launch — активный target",
             "type": "cppvsdbg",
             "request": "launch",
             "program": "${command:cmake.launchTargetPath}",
             "args": [],
             "stopAtEntry": false,
-            "cwd": "${workspaceFolder}",
-            "environment": [
+            "cwd": "${command:cmake.launchTargetDirectory}",
+            "environment": [],
+            "console": "integratedTerminal"
+        },
+        {
+            "name": "🐛 (CMake) Отладка DONTFLOAT - MinGW Debug",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/Desktop_Qt_6_9_3_MinGW_64_bit-Debug/DONTFLOAT.exe",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}/build/Desktop_Qt_6_9_3_MinGW_64_bit-Debug",
+            "targetArchitecture": "x64",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "miDebuggerPath": "C:/Qt/Tools/mingw1310_64/bin/gdb.exe",
+            "setupCommands": [
                 {
-                    "name": "PATH",
-                    "value": "C:/Qt/6.9.3/msvc2022_64/bin;C:/Qt/6.9.3/msvc2022_64/plugins/platforms;C:/Qt/6.9.3/msvc2022_64/plugins;${env:PATH}"
+                    "description": "Disable pagination",
+                    "text": "-gdb-set pagination off",
+                    "ignoreFailures": true
                 },
                 {
-                    "name": "QT_PLUGIN_PATH",
-                    "value": "C:/Qt/6.9.3/msvc2022_64/plugins"
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                },
+                {
+                    "description": "Set Disassembly Flavor to Intel",
+                    "text": "-gdb-set disassembly-flavor intel",
+                    "ignoreFailures": true
                 }
             ],
+            "preLaunchTask": "CMake: Build (Windows MinGW Debug)"
+        },
+        {
+            "name": "▶️ (CMake) Запуск DONTFLOAT - MinGW Debug",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/Desktop_Qt_6_9_3_MinGW_64_bit-Debug/DONTFLOAT.exe",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}/build/Desktop_Qt_6_9_3_MinGW_64_bit-Debug",
+            "targetArchitecture": "x64",
+            "environment": [],
+            "externalConsole": true,
+            "MIMode": "gdb",
+            "miDebuggerPath": "C:/Qt/Tools/mingw1310_64/bin/gdb.exe",
+            "preLaunchTask": "CMake: Build (Windows MinGW Debug)"
+        },
+        {
+            "name": "▶️ (CMake) Запуск DONTFLOAT - MSVC Debug",
+            "type": "cppvsdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/Desktop_Qt_6_9_3_MSVC2022_64bit-Debug/Debug/DONTFLOAT.exe",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}/build/Desktop_Qt_6_9_3_MSVC2022_64bit-Debug/Debug",
+            "environment": [],
             "console": "externalTerminal",
-            "preLaunchTask": "CMake: Build (Windows)"
+            "preLaunchTask": "CMake: Build (Windows MSVC Debug)"
         },
         {
             "name": "🐛 (CMake) Отладка DONTFLOAT - MSVC Debug",
             "type": "cppvsdbg",
             "request": "launch",
-            "program": "${command:cmake.launchTargetPath}",
+            "program": "${workspaceFolder}/build/Desktop_Qt_6_9_3_MSVC2022_64bit-Debug/Debug/DONTFLOAT.exe",
             "args": [],
             "stopAtEntry": false,
-            "cwd": "${workspaceFolder}",
-            "environment": [
-                {
-                    "name": "PATH",
-                    "value": "C:/Qt/6.9.3/msvc2022_64/bin;C:/Qt/6.9.3/msvc2022_64/plugins/platforms;C:/Qt/6.9.3/msvc2022_64/plugins;${env:PATH}"
-                },
-                {
-                    "name": "QT_PLUGIN_PATH",
-                    "value": "C:/Qt/6.9.3/msvc2022_64/plugins"
-                },
-                {
-                    "name": "QT_DEBUG_PLUGINS",
-                    "value": "1"
-                }
-            ],
-            "console": "integratedTerminal"
+            "cwd": "${workspaceFolder}/build/Desktop_Qt_6_9_3_MSVC2022_64bit-Debug/Debug",
+            "environment": [],
+            "console": "integratedTerminal",
+            "preLaunchTask": "CMake: Build (Windows MSVC Debug)"
+        },
+        {
+            "name": "▶️ (CMake) Запуск DONTFLOAT - MSVC Release",
+            "type": "cppvsdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/Desktop_Qt_6_9_3_MSVC2022_64bit-Release/Release/DONTFLOAT.exe",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}/build/Desktop_Qt_6_9_3_MSVC2022_64bit-Release/Release",
+            "environment": [],
+            "console": "externalTerminal",
+            "preLaunchTask": "CMake: Build Release (Windows)"
+        },
+        {
+            "name": "🐛 (CMake) Отладка DONTFLOAT - MSVC Release",
+            "type": "cppvsdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/Desktop_Qt_6_9_3_MSVC2022_64bit-Release/Release/DONTFLOAT.exe",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}/build/Desktop_Qt_6_9_3_MSVC2022_64bit-Release/Release",
+            "environment": [],
+            "console": "integratedTerminal",
+            "preLaunchTask": "CMake: Build Release (Windows)"
         },
         {
             "name": "▶️ (qmake) Запуск DONTFLOAT - MinGW Debug",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,11 +1,16 @@
 {
-    "cmake.buildDirectory": "${workspaceFolder}/build/${buildType}",
+    "cmake.buildDirectory": "${workspaceFolder}/build/Desktop_Qt_6_9_3_MSVC2022_64bit-Release",
+    "cmake.useCMakePresets": "always",
+    "cmake.configurePreset": "windows-msvc-release",
+    "cmake.buildPreset": "windows-msvc-release",
     "cmake.configureOnOpen": false,
     "cmake.buildBeforeRun": true,
+    "cmake.setBuildTargetSameAsLaunchTarget": true,
+    "cmake.launchBehavior": "newTerminal",
     "cmake.autoSelectActiveFolder": true,
     "cmake.preferredGenerators": [
-        "Visual Studio 17 2022",
         "MinGW Makefiles",
+        "Visual Studio 17 2022",
         "Ninja"
     ],
     "task.quickOpen.history": 10,
@@ -24,8 +29,8 @@
         "${workspaceFolder}/include",
         "${workspaceFolder}/ui",
         "${workspaceFolder}/build",
-        "${workspaceFolder}/build/Desktop_Qt_6_9_3_MSVC2022_64bit-Debug",
         "${workspaceFolder}/build/Desktop_Qt_6_9_3_MinGW_64_bit-Debug",
+        "${workspaceFolder}/build/Desktop_Qt_6_9_3_MSVC2022_64bit-Debug",
         "${workspaceFolder}/thirdparty/qm-dsp",
         "${workspaceFolder}/thirdparty/qm-dsp/include"
     ],
@@ -39,35 +44,15 @@
         "kiss_fft_scalar=double",
         "_USE_MATH_DEFINES"
     ],
-    "cmake.generator": "Visual Studio 17 2022",
-    "cmake.platform": "x64",
-    "cmake.configureSettings": {
-        "CMAKE_PREFIX_PATH": "C:/Qt/6.9.3/msvc2022_64"
-    },
-    "cmake.toolset": "v143",
+    "cmake.copyCompileCommands": "${workspaceFolder}/build/Desktop_Qt_6_9_3_MinGW_64_bit-Debug/compile_commands.json",
     "cmake.additionalKits": [],
-    "cmake.environment": {
-        "PATH": "C:/Qt/6.9.3/msvc2022_64/bin;C:/Qt/6.9.3/msvc2022_64/plugins/platforms;C:/Qt/6.9.3/msvc2022_64/plugins;${env:PATH}",
-        "QT_PLUGIN_PATH": "C:/Qt/6.9.3/msvc2022_64/plugins",
-        "VCToolsVersion": "14.44.35207"
-    },
     "cmake.debugConfig": {
-        "environment": [
-            {
-                "name": "PATH",
-                "value": "C:/Qt/6.9.3/msvc2022_64/bin;C:/Qt/6.9.3/msvc2022_64/plugins/platforms;C:/Qt/6.9.3/msvc2022_64/plugins;${env:PATH}"
-            },
-            {
-                "name": "QT_PLUGIN_PATH",
-                "value": "C:/Qt/6.9.3/msvc2022_64/plugins"
-            }
-        ],
-        "externalConsole": true,
-        "MIMode": "gdb",
+        "targetArchitecture": "x64",
+        "externalConsole": false,
         "stopAtEntry": false
     },
-    "C_Cpp.default.intelliSenseMode": "windows-msvc-x64",
-    "C_Cpp.default.compilerPath": "C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.44.35207/bin/Hostx64/x64/cl.exe",
+    "C_Cpp.default.intelliSenseMode": "windows-gcc-x64",
+    "C_Cpp.default.compilerPath": "C:/Qt/Tools/mingw1310_64/bin/g++.exe",
     "terminal.integrated.defaultProfile.windows": "PowerShell",
     "terminal.integrated.defaultProfile.linux": "bash",
     "terminal.integrated.profiles.linux": {
@@ -99,8 +84,8 @@
         "--completion-style=detailed",
         "--header-insertion=never",
         "--pch-storage=memory",
-        "--compile-commands-dir=${workspaceFolder}/build/Desktop_Qt_6_9_3_MSVC2022_64bit-Debug",
-        "--query-driver=C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/**/cl.exe",
+        "--compile-commands-dir=${workspaceFolder}/build/Desktop_Qt_6_9_3_MinGW_64_bit-Debug",
+        "--query-driver=C:/Qt/Tools/mingw1310_64/bin/g++.exe",
         "--clang-tidy=false"
     ],
     "clangd.fallbackFlags": [

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,20 +2,10 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "label": "CMake: Configure (Windows)",
+            "label": "CMake: Configure (Windows MSVC2022 Debug)",
             "type": "shell",
             "command": "cmake",
-            "args": [
-                "-S",
-                ".",
-                "-B",
-                "build",
-                "-G",
-                "Visual Studio 17 2022",
-                "-A",
-                "x64",
-                "-DCMAKE_PREFIX_PATH=C:/Qt/6.9.3/msvc2022_64"
-            ],
+            "args": ["--preset", "windows-msvc-debug"],
             "group": "build",
             "presentation": {
                 "echo": true,
@@ -26,54 +16,84 @@
                 "clear": false
             },
             "problemMatcher": [],
-            "detail": "Настройка CMake проекта для Visual Studio 2022",
+            "detail": "CMake configure → build/Desktop_Qt_6_9_3_MSVC2022_64bit-Debug",
             "options": {
                 "cwd": "${workspaceFolder}"
             }
         },
         {
-            "label": "CMake: Build (Windows)",
+            "label": "CMake: Build (Windows MSVC Debug)",
             "type": "shell",
             "command": "cmake",
-            "args": [
-                "--build",
-                "build",
-                "--config",
-                "Debug",
-                "-j"
+            "args": ["--build", "--preset", "windows-msvc-debug", "--parallel"],
+            "group": {
+                "kind": "build",
+                "isDefault": false
+            },
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": false,
+                "panel": "shared",
+                "showReuseMessage": true,
+                "clear": false
+            },
+            "problemMatcher": [
+                "$msCompile"
             ],
+            "detail": "CMake build MSVC2022 Debug (Desktop_Qt_6_9_3_MSVC2022_64bit-Debug)",
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "dependsOn": "CMake: Configure (Windows MSVC2022 Debug)"
+        },
+        {
+            "label": "CMake: Configure (Windows MinGW Debug)",
+            "type": "shell",
+            "command": "cmake",
+            "args": ["--preset", "windows-mingw-debug"],
+            "group": "build",
+            "presentation": {
+                "reveal": "always",
+                "panel": "shared"
+            },
+            "problemMatcher": [],
+            "detail": "CMake configure → build/Desktop_Qt_6_9_3_MinGW_64_bit-Debug",
+            "options": {
+                "cwd": "${workspaceFolder}",
+                "env": {
+                    "PATH": "C:/Qt/Tools/mingw1310_64/bin;C:/Qt/6.9.3/mingw_64/bin;${env:PATH}"
+                }
+            }
+        },
+        {
+            "label": "CMake: Build (Windows MinGW Debug)",
+            "type": "shell",
+            "command": "cmake",
+            "args": ["--build", "--preset", "windows-mingw-debug", "--parallel"],
             "group": {
                 "kind": "build",
                 "isDefault": true
             },
             "presentation": {
-                "echo": true,
                 "reveal": "always",
-                "focus": false,
-                "panel": "shared",
-                "showReuseMessage": true,
-                "clear": false
+                "panel": "shared"
             },
-            "problemMatcher": [
-                "$msCompile"
-            ],
-            "detail": "Сборка проекта через CMake (Debug)",
+            "problemMatcher": ["$gcc"],
+            "detail": "CMake build MinGW Debug (Desktop_Qt_6_9_3_MinGW_64_bit-Debug)",
             "options": {
-                "cwd": "${workspaceFolder}"
+                "cwd": "${workspaceFolder}",
+                "env": {
+                    "PATH": "C:/Qt/Tools/mingw1310_64/bin;C:/Qt/6.9.3/mingw_64/bin;${env:PATH}"
+                }
             },
-            "dependsOn": []
+            "dependsOn": "CMake: Configure (Windows MinGW Debug)"
         },
         {
             "label": "CMake: Build Release (Windows)",
             "type": "shell",
             "command": "cmake",
-            "args": [
-                "--build",
-                "build",
-                "--config",
-                "Release",
-                "-j"
-            ],
+            "args": ["--build", "--preset", "windows-msvc-release", "--parallel"],
             "group": "build",
             "presentation": {
                 "echo": true,
@@ -86,32 +106,47 @@
             "problemMatcher": [
                 "$msCompile"
             ],
-            "detail": "Сборка проекта через CMake (Release)",
+            "detail": "CMake build MSVC2022 Release",
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "dependsOn": "CMake: Configure (Windows MSVC2022 Release)"
+        },
+        {
+            "label": "CMake: Configure (Windows MSVC2022 Release)",
+            "type": "shell",
+            "command": "cmake",
+            "args": ["--preset", "windows-msvc-release"],
+            "group": "build",
+            "presentation": {
+                "reveal": "always",
+                "panel": "shared"
+            },
+            "problemMatcher": [],
+            "detail": "CMake configure → build/Desktop_Qt_6_9_3_MSVC2022_64bit-Release",
             "options": {
                 "cwd": "${workspaceFolder}"
             }
         },
         {
-            "label": "CMake: Clean (Windows)",
+            "label": "CMake: Clean (Windows MSVC2022 Debug)",
             "type": "shell",
             "command": "cmake",
             "args": [
                 "--build",
-                "build",
+                "${workspaceFolder}/build/Desktop_Qt_6_9_3_MSVC2022_64bit-Debug",
+                "--config",
+                "Debug",
                 "--target",
                 "clean"
             ],
             "group": "build",
             "presentation": {
-                "echo": true,
                 "reveal": "always",
-                "focus": false,
-                "panel": "shared",
-                "showReuseMessage": true,
-                "clear": false
+                "panel": "shared"
             },
             "problemMatcher": [],
-            "detail": "Очистка сборки CMake",
+            "detail": "Очистка CMake-сборки MSVC Debug",
             "options": {
                 "cwd": "${workspaceFolder}"
             }
@@ -122,7 +157,7 @@
             "command": "cmake",
             "args": [
                 "--build",
-                "build",
+                "${workspaceFolder}/build/Desktop_Qt_6_9_3_MSVC2022_64bit-Debug",
                 "--config",
                 "Debug",
                 "--target",
@@ -140,10 +175,11 @@
             "problemMatcher": [
                 "$msCompile"
             ],
-            "detail": "Сборка тестов",
+            "detail": "Сборка тестов (MSVC2022 Debug)",
             "options": {
                 "cwd": "${workspaceFolder}"
-            }
+            },
+            "dependsOn": "CMake: Configure (Windows MSVC2022 Debug)"
         },
         {
             "label": "CMake: Run Tests (Windows)",
@@ -151,7 +187,7 @@
             "command": "ctest",
             "args": [
                 "--test-dir",
-                "build",
+                "${workspaceFolder}/build/Desktop_Qt_6_9_3_MSVC2022_64bit-Debug",
                 "-C",
                 "Debug",
                 "--output-on-failure"
@@ -166,19 +202,19 @@
                 "clear": true
             },
             "problemMatcher": [],
-            "detail": "Запуск всех тестов через CTest",
+            "detail": "CTest MSVC2022 Debug",
             "options": {
                 "cwd": "${workspaceFolder}"
             },
             "dependsOn": "CMake: Build Tests (Windows)"
         },
         {
-            "label": "CMake: Full Rebuild (Windows)",
+            "label": "CMake: Full Rebuild (Windows MSVC2022 Debug)",
             "type": "shell",
             "command": "powershell",
             "args": [
                 "-Command",
-                "Remove-Item -Recurse -Force build -ErrorAction SilentlyContinue; cmake -S . -B build -G 'Visual Studio 17 2022' -A x64 -DCMAKE_PREFIX_PATH=C:/Qt/6.9.3/msvc2022_64; cmake --build build --config Debug -j"
+                "Remove-Item -Recurse -Force 'build/Desktop_Qt_6_9_3_MSVC2022_64bit-Debug' -ErrorAction SilentlyContinue; cmake --preset windows-msvc-debug; cmake --build --preset windows-msvc-debug --parallel"
             ],
             "group": "build",
             "presentation": {
@@ -192,7 +228,7 @@
             "problemMatcher": [
                 "$msCompile"
             ],
-            "detail": "Полная пересборка (удаление build и конфигурация заново)",
+            "detail": "Полная пересборка MSVC2022 Debug",
             "options": {
                 "cwd": "${workspaceFolder}"
             }
@@ -510,7 +546,7 @@
             ],
             "group": {
                 "kind": "build",
-                "isDefault": true
+                "isDefault": false
             },
             "presentation": {
                 "echo": true,
@@ -811,8 +847,12 @@
             ],
             "detail": "Build tests for Windows MinGW Debug",
             "options": {
-                "cwd": "${workspaceFolder}"
-            }
+                "cwd": "${workspaceFolder}",
+                "env": {
+                    "PATH": "C:/Qt/Tools/mingw1310_64/bin;C:/Qt/6.9.3/mingw_64/bin;${env:PATH}"
+                }
+            },
+            "dependsOn": "CMake: Configure (Windows MinGW Debug)"
         },
         {
             "label": "CMake: Build Tests (Windows MinGW Release)",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,10 +50,18 @@ set(CMAKE_AUTOUIC_SEARCH_PATHS ${CMAKE_CURRENT_SOURCE_DIR}/ui)
 # и/или -DCMAKE_PREFIX_PATH (Homebrew qt@6, ~/Qt/6.x/macos|gcc_64).
 set(QT_MIN_VERSION "6.8.0")
 if(WIN32)
-    if(EXISTS "C:/Qt/6.9.3/msvc2022_64")
-        list(PREPEND CMAKE_PREFIX_PATH "C:/Qt/6.9.3/msvc2022_64")
-    elseif(EXISTS "C:/Qt/6.8.3/msvc2022_64")
-        list(PREPEND CMAKE_PREFIX_PATH "C:/Qt/6.8.3/msvc2022_64")
+    if(MSVC)
+        if(NOT "C:/Qt/6.9.3/msvc2022_64" IN_LIST CMAKE_PREFIX_PATH AND EXISTS "C:/Qt/6.9.3/msvc2022_64")
+            list(PREPEND CMAKE_PREFIX_PATH "C:/Qt/6.9.3/msvc2022_64")
+        elseif(NOT "C:/Qt/6.8.3/msvc2022_64" IN_LIST CMAKE_PREFIX_PATH AND EXISTS "C:/Qt/6.8.3/msvc2022_64")
+            list(PREPEND CMAKE_PREFIX_PATH "C:/Qt/6.8.3/msvc2022_64")
+        endif()
+    elseif(MINGW)
+        if(NOT "C:/Qt/6.9.3/mingw_64" IN_LIST CMAKE_PREFIX_PATH AND EXISTS "C:/Qt/6.9.3/mingw_64")
+            list(PREPEND CMAKE_PREFIX_PATH "C:/Qt/6.9.3/mingw_64")
+        elseif(NOT "C:/Qt/6.8.3/mingw_64" IN_LIST CMAKE_PREFIX_PATH AND EXISTS "C:/Qt/6.8.3/mingw_64")
+            list(PREPEND CMAKE_PREFIX_PATH "C:/Qt/6.8.3/mingw_64")
+        endif()
     endif()
 else()
     include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/PlatformQt.cmake)
@@ -72,19 +80,15 @@ find_package(Qt6 ${QT_MIN_VERSION} REQUIRED COMPONENTS
     Test
 )
 
-# Каталог Qt для CTest на Windows (PATH к DLL); на Linux не используется.
+# Каталог Qt для CTest на Windows (PATH к DLL); берём из найденного Qt6_DIR (MSVC или MinGW).
 if(WIN32)
-    if(EXISTS "C:/Qt/6.9.3/msvc2022_64")
-        set(QT_ROOT_DIR "C:/Qt/6.9.3/msvc2022_64")
-    elseif(EXISTS "C:/Qt/6.8.3/msvc2022_64")
-        set(QT_ROOT_DIR "C:/Qt/6.8.3/msvc2022_64")
-    else()
-        get_filename_component(_qt6_cmake_parent "${Qt6_DIR}" DIRECTORY)
-        get_filename_component(_qt6_lib "${_qt6_cmake_parent}" DIRECTORY)
-        get_filename_component(QT_ROOT_DIR "${_qt6_lib}" DIRECTORY)
-    endif()
+    get_filename_component(_qt6_cmake_parent "${Qt6_DIR}" DIRECTORY)
+    get_filename_component(_qt6_lib "${_qt6_cmake_parent}" DIRECTORY)
+    get_filename_component(QT_ROOT_DIR "${_qt6_lib}" DIRECTORY)
     set(QT_ROOT_DIR "${QT_ROOT_DIR}" CACHE PATH "Qt6 root (Windows CTest / DLL PATH)" FORCE)
     message(STATUS "Используется Qt: ${QT_ROOT_DIR}")
+    unset(_qt6_cmake_parent)
+    unset(_qt6_lib)
 endif()
 
 # Add source files
@@ -336,12 +340,15 @@ else()
     )
 endif()
 
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/WinDeployQt.cmake)
+
 # Платформенные свойства исполняемого файла
 if(WIN32)
     set_target_properties(${PROJECT_NAME} PROPERTIES
         WIN32_EXECUTABLE TRUE
         MACOSX_BUNDLE FALSE
     )
+    dontfloat_deploy_qt(${PROJECT_NAME})
 elseif(APPLE)
     # Обычный бинарник в build/macos/DONTFLOAT; .app — через tools/macos_build.sh deploy
     set_target_properties(${PROJECT_NAME} PROPERTIES
@@ -552,7 +559,11 @@ endif()
 dontfloat_link_rubberband(marker_testgen)
 
 if(WIN32)
-    target_link_options(marker_testgen PRIVATE /SUBSYSTEM:WINDOWS /ENTRY:mainCRTStartup)
+    set_target_properties(marker_testgen PROPERTIES WIN32_EXECUTABLE TRUE)
+    if(MSVC)
+        target_link_options(marker_testgen PRIVATE /SUBSYSTEM:WINDOWS /ENTRY:mainCRTStartup)
+    endif()
+    dontfloat_deploy_qt(marker_testgen)
 endif()
 
 add_qt_test(markersfile_test

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -71,6 +71,84 @@
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Release"
             }
+        },
+        {
+            "name": "windows-msvc-debug",
+            "displayName": "Windows MSVC2022 Debug",
+            "generator": "Visual Studio 17 2022",
+            "architecture": "x64",
+            "toolset": "v143",
+            "binaryDir": "${sourceDir}/build/Desktop_Qt_6_9_3_MSVC2022_64bit-Debug",
+            "cacheVariables": {
+                "CMAKE_PREFIX_PATH": "C:/Qt/6.9.3/msvc2022_64",
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+            },
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            }
+        },
+        {
+            "name": "windows-msvc-release",
+            "displayName": "Windows MSVC2022 Release",
+            "generator": "Visual Studio 17 2022",
+            "architecture": "x64",
+            "toolset": "v143",
+            "binaryDir": "${sourceDir}/build/Desktop_Qt_6_9_3_MSVC2022_64bit-Release",
+            "cacheVariables": {
+                "CMAKE_PREFIX_PATH": "C:/Qt/6.9.3/msvc2022_64",
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+            },
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            }
+        },
+        {
+            "name": "windows-mingw-debug",
+            "displayName": "Windows MinGW Debug",
+            "generator": "MinGW Makefiles",
+            "binaryDir": "${sourceDir}/build/Desktop_Qt_6_9_3_MinGW_64_bit-Debug",
+            "environment": {
+                "PATH": "C:/Qt/Tools/mingw1310_64/bin;C:/Qt/6.9.3/mingw_64/bin;$penv{PATH}"
+            },
+            "cacheVariables": {
+                "CMAKE_PREFIX_PATH": "C:/Qt/6.9.3/mingw_64",
+                "CMAKE_BUILD_TYPE": "Debug",
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+                "CMAKE_MAKE_PROGRAM": "C:/Qt/Tools/mingw1310_64/bin/mingw32-make.exe",
+                "CMAKE_C_COMPILER": "C:/Qt/Tools/mingw1310_64/bin/gcc.exe",
+                "CMAKE_CXX_COMPILER": "C:/Qt/Tools/mingw1310_64/bin/g++.exe"
+            },
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            }
+        },
+        {
+            "name": "windows-mingw-release",
+            "displayName": "Windows MinGW Release",
+            "generator": "MinGW Makefiles",
+            "binaryDir": "${sourceDir}/build/Desktop_Qt_6_9_3_MinGW_64_bit-Release",
+            "environment": {
+                "PATH": "C:/Qt/Tools/mingw1310_64/bin;C:/Qt/6.9.3/mingw_64/bin;$penv{PATH}"
+            },
+            "cacheVariables": {
+                "CMAKE_PREFIX_PATH": "C:/Qt/6.9.3/mingw_64",
+                "CMAKE_BUILD_TYPE": "Release",
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+                "CMAKE_MAKE_PROGRAM": "C:/Qt/Tools/mingw1310_64/bin/mingw32-make.exe",
+                "CMAKE_C_COMPILER": "C:/Qt/Tools/mingw1310_64/bin/gcc.exe",
+                "CMAKE_CXX_COMPILER": "C:/Qt/Tools/mingw1310_64/bin/g++.exe"
+            },
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            }
         }
     ],
     "buildPresets": [
@@ -89,6 +167,24 @@
         {
             "name": "macos-release",
             "configurePreset": "macos-release"
+        },
+        {
+            "name": "windows-msvc-debug",
+            "configurePreset": "windows-msvc-debug",
+            "configuration": "Debug"
+        },
+        {
+            "name": "windows-msvc-release",
+            "configurePreset": "windows-msvc-release",
+            "configuration": "Release"
+        },
+        {
+            "name": "windows-mingw-debug",
+            "configurePreset": "windows-mingw-debug"
+        },
+        {
+            "name": "windows-mingw-release",
+            "configurePreset": "windows-mingw-release"
         }
     ],
     "testPresets": [
@@ -105,6 +201,15 @@
             "environment": {
                 "QT_QPA_PLATFORM": "offscreen"
             }
+        },
+        {
+            "name": "windows-msvc-debug",
+            "configurePreset": "windows-msvc-debug",
+            "configuration": "Debug"
+        },
+        {
+            "name": "windows-mingw-debug",
+            "configurePreset": "windows-mingw-debug"
         }
     ]
 }

--- a/cmake/WinDeployQt.cmake
+++ b/cmake/WinDeployQt.cmake
@@ -1,0 +1,42 @@
+# Развёртывание Qt DLL рядом с exe на Windows (windeployqt).
+# Без этого GUI-приложение падает при запуске без Qt в PATH.
+
+function(dontfloat_deploy_qt target)
+    if(NOT WIN32)
+        return()
+    endif()
+
+    if(NOT WINDEPLOYQT_EXECUTABLE)
+        find_program(WINDEPLOYQT_EXECUTABLE
+            NAMES windeployqt windeployqt.exe
+            HINTS
+                "${QT_ROOT_DIR}/bin"
+                "${Qt6_DIR}/../../../bin"
+        )
+    endif()
+
+    if(NOT WINDEPLOYQT_EXECUTABLE)
+        message(WARNING "windeployqt not found; ${target} needs Qt bin on PATH to run")
+        return()
+    endif()
+
+    if(MINGW)
+        # MinGW: не передавать --debug/--release — windeployqt сам читает PE-зависимости.
+        # Явный --debug ломает деплой плагинов (нет qwindowsd.dll в Qt for MinGW).
+        add_custom_command(TARGET ${target} POST_BUILD
+            COMMAND "${WINDEPLOYQT_EXECUTABLE}"
+                --no-compiler-runtime
+                "$<TARGET_FILE:${target}>"
+            COMMENT "windeployqt (MinGW): ${target}"
+            VERBATIM
+        )
+    else()
+        add_custom_command(TARGET ${target} POST_BUILD
+            COMMAND "${WINDEPLOYQT_EXECUTABLE}"
+                "$<IF:$<CONFIG:Debug>,--debug,--release>"
+                "$<TARGET_FILE:${target}>"
+            COMMENT "windeployqt (MSVC): ${target}"
+            VERBATIM
+        )
+    endif()
+endfunction()


### PR DESCRIPTION
Add Windows CMake presets for MSVC and MinGW, deploy Qt DLLs via windeployqt after build, fix marker_testgen linking on MinGW, and align VS Code launch/tasks so F5 and the CMake Play button run DONTFLOAT from the exe directory without manual PATH setup.