### PR TITLE
feat(plugins): добавить pitch shift targets для CLAP и LV2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,13 @@ endif()
 # Генерируем compile_commands.json для IntelliSense
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+option(DONTFLOAT_BUILD_PLUGINS "Build DAW plugin targets" OFF)
+option(DONTFLOAT_BUILD_CLAP "Build CLAP plugin target when plugins are enabled" ON)
+option(DONTFLOAT_BUILD_LV2 "Build LV2 plugin target when plugins are enabled" ON)
+option(DONTFLOAT_BUILD_VST3 "Build VST3 plugin target when SDK is available" OFF)
+set(DONTFLOAT_CLAP_SDK_ROOT "" CACHE PATH "Optional path to official CLAP SDK")
+set(DONTFLOAT_VST3_SDK_ROOT "" CACHE PATH "Optional path to VST3 SDK")
+
 find_package(Qt6 ${QT_MIN_VERSION} REQUIRED COMPONENTS
     Core
     Gui
@@ -220,6 +227,158 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
 )
 dontfloat_link_rubberband(${PROJECT_NAME})
 
+if(DONTFLOAT_BUILD_PLUGINS)
+    add_library(dontfloat_plugin_core STATIC
+        plugins/core/dontfloat_plugin_core.cpp
+        plugins/core/dontfloat_plugin_core.h
+    )
+    target_compile_features(dontfloat_plugin_core PUBLIC cxx_std_17)
+    target_include_directories(dontfloat_plugin_core PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/plugins/core
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+    )
+
+    if(DONTFLOAT_BUILD_CLAP)
+        add_library(dontfloat_pitch_shift_clap MODULE
+            plugins/clap/dontfloat_clap_pitch_shift.cpp
+            plugins/clap/clap_minimal.h
+        )
+        target_compile_features(dontfloat_pitch_shift_clap PRIVATE cxx_std_17)
+        target_link_libraries(dontfloat_pitch_shift_clap PRIVATE dontfloat_plugin_core)
+        target_include_directories(dontfloat_pitch_shift_clap PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/plugins/clap
+            ${CMAKE_CURRENT_SOURCE_DIR}/plugins/core
+        )
+        set_target_properties(dontfloat_pitch_shift_clap PROPERTIES
+            PREFIX ""
+            OUTPUT_NAME "dontfloat_pitch_shift"
+            SUFFIX ".clap"
+        )
+
+        add_executable(clap_pitch_shift_smoke_test
+            plugins/clap/tests/clap_pitch_shift_smoke_test.cpp
+            plugins/clap/dontfloat_clap_pitch_shift.cpp
+        )
+        target_compile_features(clap_pitch_shift_smoke_test PRIVATE cxx_std_17)
+        target_link_libraries(clap_pitch_shift_smoke_test PRIVATE dontfloat_plugin_core)
+        target_include_directories(clap_pitch_shift_smoke_test PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/plugins/clap
+            ${CMAKE_CURRENT_SOURCE_DIR}/plugins/core
+        )
+        add_test(NAME clap_pitch_shift_smoke_test COMMAND clap_pitch_shift_smoke_test)
+        set_tests_properties(clap_pitch_shift_smoke_test PROPERTIES
+            LABELS "plugins;clap;pitch"
+            DESCRIPTION "Smoke test for DONTFLOAT CLAP pitch shift factory and process path"
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        )
+
+        install(TARGETS dontfloat_pitch_shift_clap
+            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/clap
+            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}/clap
+            OPTIONAL
+        )
+    endif()
+
+    if(DONTFLOAT_BUILD_LV2)
+        add_library(dontfloat_pitch_shift_lv2 MODULE
+            plugins/lv2/dontfloat_lv2_pitch_shift.cpp
+            plugins/lv2/lv2_minimal.h
+        )
+        target_compile_features(dontfloat_pitch_shift_lv2 PRIVATE cxx_std_17)
+        target_link_libraries(dontfloat_pitch_shift_lv2 PRIVATE dontfloat_plugin_core)
+        target_include_directories(dontfloat_pitch_shift_lv2 PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/plugins/lv2
+            ${CMAKE_CURRENT_SOURCE_DIR}/plugins/core
+        )
+        set_target_properties(dontfloat_pitch_shift_lv2 PROPERTIES
+            PREFIX ""
+            OUTPUT_NAME "dontfloat_pitch_shift"
+            ARCHIVE_OUTPUT_NAME "dontfloat_pitch_shift_lv2_import"
+            LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/plugins/lv2/dontfloat_pitch_shift.lv2"
+            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/plugins/lv2/dontfloat_pitch_shift.lv2"
+            LIBRARY_OUTPUT_DIRECTORY_DEBUG "${CMAKE_CURRENT_BINARY_DIR}/plugins/lv2/dontfloat_pitch_shift.lv2"
+            RUNTIME_OUTPUT_DIRECTORY_DEBUG "${CMAKE_CURRENT_BINARY_DIR}/plugins/lv2/dontfloat_pitch_shift.lv2"
+            LIBRARY_OUTPUT_DIRECTORY_RELEASE "${CMAKE_CURRENT_BINARY_DIR}/plugins/lv2/dontfloat_pitch_shift.lv2"
+            RUNTIME_OUTPUT_DIRECTORY_RELEASE "${CMAKE_CURRENT_BINARY_DIR}/plugins/lv2/dontfloat_pitch_shift.lv2"
+            LIBRARY_OUTPUT_DIRECTORY_RELWITHDEBINFO "${CMAKE_CURRENT_BINARY_DIR}/plugins/lv2/dontfloat_pitch_shift.lv2"
+            RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO "${CMAKE_CURRENT_BINARY_DIR}/plugins/lv2/dontfloat_pitch_shift.lv2"
+            LIBRARY_OUTPUT_DIRECTORY_MINSIZEREL "${CMAKE_CURRENT_BINARY_DIR}/plugins/lv2/dontfloat_pitch_shift.lv2"
+            RUNTIME_OUTPUT_DIRECTORY_MINSIZEREL "${CMAKE_CURRENT_BINARY_DIR}/plugins/lv2/dontfloat_pitch_shift.lv2"
+        )
+
+        if(WIN32)
+            set(_dontfloat_lv2_binary_ext ".dll")
+        elseif(APPLE)
+            set(_dontfloat_lv2_binary_ext ".dylib")
+        else()
+            set(_dontfloat_lv2_binary_ext ".so")
+        endif()
+        set(LV2_BINARY_EXT "${_dontfloat_lv2_binary_ext}")
+        configure_file(
+            ${CMAKE_CURRENT_SOURCE_DIR}/plugins/lv2/dontfloat_pitch_shift.lv2/manifest.ttl
+            ${CMAKE_CURRENT_BINARY_DIR}/plugins/lv2/dontfloat_pitch_shift.lv2/manifest.ttl
+            @ONLY
+        )
+        configure_file(
+            ${CMAKE_CURRENT_SOURCE_DIR}/plugins/lv2/dontfloat_pitch_shift.lv2/dontfloat_pitch_shift.ttl
+            ${CMAKE_CURRENT_BINARY_DIR}/plugins/lv2/dontfloat_pitch_shift.lv2/dontfloat_pitch_shift.ttl
+            COPYONLY
+        )
+
+        add_executable(lv2_pitch_shift_smoke_test
+            plugins/lv2/tests/lv2_pitch_shift_smoke_test.cpp
+            plugins/lv2/dontfloat_lv2_pitch_shift.cpp
+        )
+        target_compile_features(lv2_pitch_shift_smoke_test PRIVATE cxx_std_17)
+        target_link_libraries(lv2_pitch_shift_smoke_test PRIVATE dontfloat_plugin_core)
+        target_include_directories(lv2_pitch_shift_smoke_test PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/plugins/lv2
+            ${CMAKE_CURRENT_SOURCE_DIR}/plugins/core
+        )
+        add_test(NAME lv2_pitch_shift_smoke_test COMMAND lv2_pitch_shift_smoke_test)
+        set_tests_properties(lv2_pitch_shift_smoke_test PROPERTIES
+            LABELS "plugins;lv2;pitch"
+            DESCRIPTION "Smoke test for DONTFLOAT LV2 pitch shift descriptor and run path"
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        )
+
+        install(TARGETS dontfloat_pitch_shift_lv2
+            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/lv2/dontfloat_pitch_shift.lv2
+            RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR}/lv2/dontfloat_pitch_shift.lv2
+            OPTIONAL
+        )
+        install(FILES
+            ${CMAKE_CURRENT_BINARY_DIR}/plugins/lv2/dontfloat_pitch_shift.lv2/manifest.ttl
+            ${CMAKE_CURRENT_BINARY_DIR}/plugins/lv2/dontfloat_pitch_shift.lv2/dontfloat_pitch_shift.ttl
+            DESTINATION ${CMAKE_INSTALL_LIBDIR}/lv2/dontfloat_pitch_shift.lv2
+            OPTIONAL
+        )
+    endif()
+
+    if(DONTFLOAT_BUILD_VST3)
+        if(DONTFLOAT_VST3_SDK_ROOT AND EXISTS "${DONTFLOAT_VST3_SDK_ROOT}/CMakeLists.txt")
+            message(STATUS "VST3 SDK found: ${DONTFLOAT_VST3_SDK_ROOT}")
+            add_library(dontfloat_pitch_shift_vst3 MODULE
+                plugins/vst3/dontfloat_vst3_pitch_shift.cpp
+            )
+            target_compile_features(dontfloat_pitch_shift_vst3 PRIVATE cxx_std_17)
+            target_compile_definitions(dontfloat_pitch_shift_vst3 PRIVATE DONTFLOAT_HAS_VST3_SDK)
+            target_link_libraries(dontfloat_pitch_shift_vst3 PRIVATE dontfloat_plugin_core)
+            target_include_directories(dontfloat_pitch_shift_vst3 PRIVATE
+                ${CMAKE_CURRENT_SOURCE_DIR}/plugins/core
+                ${DONTFLOAT_VST3_SDK_ROOT}
+            )
+            set_target_properties(dontfloat_pitch_shift_vst3 PROPERTIES
+                PREFIX ""
+                OUTPUT_NAME "DONTFLOAT Pitch Shift"
+                SUFFIX ".vst3"
+            )
+        else()
+            message(WARNING "DONTFLOAT_BUILD_VST3=ON, but DONTFLOAT_VST3_SDK_ROOT does not point to a VST3 SDK. Skipping VST3 target.")
+        endif()
+    endif()
+endif()
+
 # Translations: build .qm from .ts (output in build dir; app loads from applicationDirPath())
 find_package(Qt6 REQUIRED COMPONENTS LinguistTools)
 qt_add_lrelease(DONTFLOAT_lrelease
@@ -357,6 +516,22 @@ endif()
 
 # Enable testing
 enable_testing()
+
+if(DONTFLOAT_BUILD_PLUGINS)
+    add_executable(plugin_core_pitch_shift_test
+        plugins/core/tests/plugin_core_pitch_shift_test.cpp
+    )
+    target_link_libraries(plugin_core_pitch_shift_test PRIVATE dontfloat_plugin_core)
+    target_include_directories(plugin_core_pitch_shift_test PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/plugins/core
+    )
+    add_test(NAME plugin_core_pitch_shift_test COMMAND plugin_core_pitch_shift_test)
+    set_tests_properties(plugin_core_pitch_shift_test PROPERTIES
+        LABELS "plugins;core;pitch"
+        DESCRIPTION "Smoke tests for DONTFLOAT plugin core pitch shift"
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+endif()
 
 # Функция для создания тестового исполняемого файла
 function(add_qt_test test_name)

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,0 +1,171 @@
+# Плагины DONTFLOAT
+
+Каталог содержит первый слой плагинов для DAW. По умолчанию plugin targets
+не собираются и не влияют на обычный `DONTFLOAT`; включаются через CMake option
+`DONTFLOAT_BUILD_PLUGINS`.
+
+Цель этого каталога — держать отдельные plugin targets, которые используют уже
+существующие DSP-ядра проекта без зависимости от GUI.
+
+## Возможные форматы
+
+### VST3
+- Основной формат для Windows и macOS, также поддерживается многими DAW на Linux.
+- Ожидаемая структура: `.vst3` bundle с тонкой обёрткой над общим DSP-ядром.
+- Начат SDK-gated target `dontfloat_pitch_shift_vst3` (`DONTFLOAT_BUILD_VST3=ON`
+  + `DONTFLOAT_VST3_SDK_ROOT`).
+
+### CLAP
+- Перспективный кроссплатформенный формат для Windows, macOS и Linux.
+- Подходит для более современного event/model API и future-proof интеграции.
+- Первый MVP реализован как `dontfloat_pitch_shift_clap`.
+
+### LV2
+- В первую очередь Linux-экосистема.
+- Можно рассматривать как отдельную цель после выделения общего plugin core.
+- Первый MVP реализован как `dontfloat_pitch_shift_lv2` с `.ttl` manifest.
+
+## Что уже есть в проекте
+
+Эти компоненты можно вынести в общее ядро для плагинов:
+
+| Компонент | Файлы | Назначение |
+|---|---|---|
+| Time stretch с тонкомпенсацией | `TimeStretchProcessor`, `RubberBandOffline` | Офлайн сжатие/растяжение по коэффициенту или меткам через Rubber Band R3 |
+| Гранулярный pitch shift | `include/granularpitchshifter_engine.h` | Сдвиг высоты в полутонах, grain rate, shape, jitter, wet, prefilter |
+| BPM / beat grid | `BPMAnalyzer` | Анализ BPM, долей, отклонений и опорной точки сетки через qm-dsp |
+| Анализ тональности | `KeyAnalyzer` | Основная/вторичная тональность, chroma vector |
+| Маркеры растяжения | `MarkerData`, `MarkerEngine` | Данные меток и расчёт сегментов для stretch |
+| Экспорт WAV | `WavWriter` | Запись обработанного аудио во временный или пользовательский WAV |
+
+Важно: часть этих классов использует Qt-типы (`QVector`, `QString`). Для
+плагинов лучше выделить слой `plugin_core` с минимальными зависимостями:
+`std::vector<float>`, plain structs, без `QWidget`, `QMediaPlayer` и `QSettings`.
+
+## Предлагаемая структура
+
+```text
+plugins/
+├── README.md
+├── core/
+│   ├── README.md
+│   ├── dontfloat_plugin_core.h
+│   ├── dontfloat_plugin_core.cpp
+│   └── tests/
+├── vst3/
+│   ├── README.md
+│   └── dontfloat_vst3_pitch_shift.cpp
+├── clap/
+│   ├── README.md
+│   ├── clap_minimal.h
+│   └── dontfloat_clap_pitch_shift.cpp
+└── lv2/
+    ├── README.md
+    ├── lv2_minimal.h
+    ├── dontfloat_lv2_pitch_shift.cpp
+    └── dontfloat_pitch_shift.lv2/
+```
+
+`core/` должен содержать только DSP и сериализуемые параметры. Форматные
+обёртки (`vst3/`, `clap/`, `lv2/`) должны заниматься только API хоста:
+инициализация, параметры, аудиобуферы, состояние пресета.
+
+Локальная документация:
+
+- [`core/README.md`](core/README.md) — общий DSP-слой без GUI.
+- [`vst3/README.md`](vst3/README.md) — будущая VST3-обёртка.
+- [`clap/README.md`](clap/README.md) — CLAP MVP для pitch shift.
+- [`lv2/README.md`](lv2/README.md) — будущий LV2 bundle.
+
+## Сборка
+
+По умолчанию плагины отключены. Включить:
+
+```powershell
+cmake -S . -B build/plugins -DDONTFLOAT_BUILD_PLUGINS=ON -DDONTFLOAT_BUILD_CLAP=ON -DDONTFLOAT_BUILD_LV2=ON
+cmake --build build/plugins --target plugin_core_pitch_shift_test dontfloat_pitch_shift_clap dontfloat_pitch_shift_lv2
+ctest --test-dir build/plugins -R plugin_core_pitch_shift_test --output-on-failure
+```
+
+Цели:
+
+- `dontfloat_plugin_core` — static library общего DSP API.
+- `dontfloat_pitch_shift_clap` — CLAP module `dontfloat_pitch_shift.clap`.
+- `dontfloat_pitch_shift_lv2` — LV2 module и bundle metadata.
+- `dontfloat_pitch_shift_vst3` — VST3 starter target, только при доступном SDK.
+- `plugin_core_pitch_shift_test` — smoke-тест core.
+- `clap_pitch_shift_smoke_test` — проверка CLAP factory, extensions и process path.
+- `lv2_pitch_shift_smoke_test` — проверка LV2 descriptor, instantiate и run path.
+
+Дополнительные CMake-переменные:
+
+- `DONTFLOAT_BUILD_PLUGINS=ON/OFF` — включает plugin targets.
+- `DONTFLOAT_BUILD_CLAP=ON/OFF` — включает CLAP target.
+- `DONTFLOAT_BUILD_LV2=ON/OFF` — включает LV2 target.
+- `DONTFLOAT_BUILD_VST3=ON/OFF` — включает VST3 target при наличии SDK.
+- `DONTFLOAT_CLAP_SDK_ROOT` — зарезервировано под официальный CLAP SDK.
+- `DONTFLOAT_VST3_SDK_ROOT` — зарезервировано под VST3 SDK.
+
+Установка:
+
+- CLAP: `${CMAKE_INSTALL_LIBDIR}/clap` или `${CMAKE_INSTALL_BINDIR}/clap` на Windows.
+- LV2: `${CMAKE_INSTALL_LIBDIR}/lv2/dontfloat_pitch_shift.lv2`.
+
+## Первые кандидаты для плагинов
+
+### DONTFLOAT Time Stretch
+- Параметры: `timeRatio`, `preservePitch`, optional marker map.
+- Основа: `TimeStretchProcessor::processChannels()` и
+  `TimeStretchProcessor::applyMarkerStretch()`.
+- Реалистичный режим: offline / render-time. Для realtime нужны отдельные
+  ограничения по latency и буферизации.
+
+### DONTFLOAT Pitch Shift
+- Параметры: `enabled`, `pitchSemitones`, `grainHz`, `shape`, `jitter`, `wet`,
+  `prefilter`.
+- Основа: `GranularEngine::Params` и `GranularEngine::applyPitchShiftQt()`.
+- Лучше подходит для realtime, чем Rubber Band offline stretch.
+- Реализовано в MVP через `PitchShiftProcessor` и CLAP wrapper.
+
+### DONTFLOAT Analyzer
+- Параметры: min/max BPM, fixed tempo, trust file BPM, key analysis.
+- Основа: `BPMAnalyzer` и `KeyAnalyzer`.
+- Может быть отдельным utility-плагином или offline анализатором, если формат
+  хоста поддерживает такой workflow.
+
+## Как это должно работать
+
+### Windows
+- Установщик кладёт общую библиотеку ядра рядом с приложением или плагином.
+- `.vst3`/`.clap` хранит относительный путь к этой библиотеке либо линкуется с
+  ядром статически.
+- Для DAW плагин должен быть самодостаточным: если приложение DONTFLOAT не
+  установлено, плагин всё равно должен корректно сообщить об ошибке или иметь
+  всё необходимое внутри bundle.
+
+### Linux / macOS
+- CLAP/LV2/VST3 bundle содержит shared library (`.so`/`.dylib`) и manifest.
+- Общий DSP-код лучше линковать статически в плагин, чтобы избежать проблем с
+  путями загрузчика и версиями библиотек.
+- Для macOS понадобится bundle layout и подпись/нотаризация на этапе релиза.
+
+## Ограничения и риски
+
+- Rubber Band и qm-dsp имеют GPL-совместимые лицензии; плагин должен
+  распространяться в рамках совместимой лицензии проекта.
+- GUI-код (`MainWindow`, `WaveformView`, `PitchGridWidget`) нельзя тащить в
+  plugin core. Плагин должен иметь собственный минимальный editor UI или
+  использовать generic UI хоста.
+- Realtime-аудио не должно выделять память, логировать в горячем пути или
+  обращаться к файловой системе из callback.
+- Текущий time stretch через Rubber Band используется как offline R3; для
+  realtime-плагина сначала нужен отдельный streaming design.
+
+## План интеграции
+
+1. Выделить `plugins/core` и перенести туда независимые DSP-обёртки.
+2. Добавить CMake option, например `DONTFLOAT_BUILD_PLUGINS`.
+3. Сделать минимальный CLAP или VST3 proof-of-concept для pitch shift.
+4. Добавить тесты на совпадение результата plugin core с текущими функциями
+   приложения.
+5. После стабилизации добавить installer layout для Windows/macOS/Linux.

--- a/plugins/clap/README.md
+++ b/plugins/clap/README.md
@@ -1,0 +1,87 @@
+# DONTFLOAT CLAP
+
+`plugins/clap` содержит первый CLAP MVP над `plugins/core`.
+
+## Почему CLAP
+
+- Кроссплатформенный формат для Windows, macOS и Linux.
+- Хорошо подходит для современных параметров, automation и event model.
+- Формат проще держать независимым от GUI-приложения DONTFLOAT.
+
+## Реализованный плагин
+
+`DONTFLOAT Pitch Shift`:
+
+- realtime-обработка через `GranularEngine`;
+- параметры: `enabled`, `pitchSemitones`, `grainHz`, `shape`, `jitter`, `wet`,
+  `prefilter`;
+- stereo in / stereo out;
+- без собственного editor UI на первом этапе.
+- descriptor id: `com.dontfloat.pitch-shift`;
+- CMake target: `dontfloat_pitch_shift_clap`;
+- output: `dontfloat_pitch_shift.clap`.
+
+`DONTFLOAT Time Stretch` лучше оставить вторым этапом: текущий Rubber Band R3
+используется как offline stretch и требует отдельной streaming-архитектуры.
+
+## Структура
+
+Текущая структура:
+
+```text
+plugins/clap/
+├── README.md
+├── clap_minimal.h
+└── dontfloat_clap_pitch_shift.cpp
+```
+
+CLAP-слой должен выполнять только задачи формата:
+
+- объявление plugin descriptor;
+- создание и уничтожение инстанса;
+- обработка аудиобуферов и events;
+- синхронизация параметров с host automation;
+- сохранение и восстановление state.
+
+DSP должен оставаться в `plugins/core`.
+
+## Realtime-правила
+
+- `process()` не выделяет память.
+- Параметры передаются lock-free или через заранее подготовленные snapshots.
+- Никакого доступа к Qt UI, файлам, настройкам приложения или логированию в
+  audio callback.
+- Все буферы и временные структуры подготавливаются в `activate()` /
+  `start_processing()`.
+
+## Интеграция со сборкой
+
+CLAP подключён к корневому `CMakeLists.txt` за опциями:
+
+```cmake
+option(DONTFLOAT_BUILD_PLUGINS "Build DAW plugins" OFF)
+option(DONTFLOAT_BUILD_CLAP "Build CLAP plugin target when plugins are enabled" ON)
+set(DONTFLOAT_CLAP_SDK_ROOT "" CACHE PATH "Optional path to official CLAP SDK")
+```
+
+Сейчас используется локальный минимальный ABI subset `clap_minimal.h`, чтобы
+MVP собирался без скачивания SDK. `DONTFLOAT_CLAP_SDK_ROOT` зарезервирован для
+перехода на официальный SDK.
+
+Сборка:
+
+```powershell
+cmake -S . -B build/plugins -DDONTFLOAT_BUILD_PLUGINS=ON -DDONTFLOAT_BUILD_CLAP=ON
+cmake --build build/plugins --target dontfloat_pitch_shift_clap clap_pitch_shift_smoke_test
+ctest --test-dir build/plugins -R clap_pitch_shift_smoke_test --output-on-failure
+```
+
+Install rule кладёт CLAP module в `${CMAKE_INSTALL_LIBDIR}/clap` или
+`${CMAKE_INSTALL_BINDIR}/clap` на Windows.
+
+## Проверка
+
+1. Собрать CLAP target.
+2. Проверить descriptor в CLAP validator / тестовом host.
+3. Сравнить render результата с прямым вызовом `plugins/core`.
+4. Проверить automation каждого параметра.

--- a/plugins/clap/clap_minimal.h
+++ b/plugins/clap/clap_minimal.h
@@ -1,0 +1,191 @@
+#ifndef DONTFLOAT_CLAP_MINIMAL_H
+#define DONTFLOAT_CLAP_MINIMAL_H
+
+#include <cstdint>
+
+#if defined(_WIN32)
+#define CLAP_EXPORT __declspec(dllexport)
+#else
+#define CLAP_EXPORT __attribute__((visibility("default")))
+#endif
+
+#define CLAP_PLUGIN_FACTORY_ID "clap.plugin-factory"
+#define CLAP_EXT_PARAMS "clap.params"
+#define CLAP_EXT_AUDIO_PORTS "clap.audio-ports"
+#define CLAP_PORT_STEREO "stereo"
+
+#define CLAP_CORE_EVENT_SPACE_ID 0
+#define CLAP_EVENT_PARAM_VALUE 5
+
+#define CLAP_PARAM_IS_AUTOMATABLE (1u << 0)
+#define CLAP_AUDIO_PORT_IS_MAIN (1u << 0)
+
+using clap_id = uint32_t;
+
+struct clap_version_t {
+    uint32_t major;
+    uint32_t minor;
+    uint32_t revision;
+};
+
+#define CLAP_VERSION_INIT {1, 2, 0}
+
+struct clap_host_t;
+struct clap_plugin_t;
+struct clap_plugin_descriptor_t;
+struct clap_plugin_factory_t;
+struct clap_plugin_entry_t;
+struct clap_process_t;
+struct clap_input_events_t;
+struct clap_output_events_t;
+
+enum clap_process_status {
+    CLAP_PROCESS_ERROR = 0,
+    CLAP_PROCESS_CONTINUE = 1,
+    CLAP_PROCESS_CONTINUE_IF_NOT_QUIET = 2,
+    CLAP_PROCESS_TAIL = 3,
+    CLAP_PROCESS_SLEEP = 4,
+};
+
+struct clap_event_header_t {
+    uint32_t size;
+    uint32_t time;
+    uint16_t space_id;
+    uint16_t type;
+    uint32_t flags;
+};
+
+struct clap_event_param_value_t {
+    clap_event_header_t header;
+    clap_id param_id;
+    void* cookie;
+    int16_t note_id;
+    int16_t port_index;
+    int16_t channel;
+    int16_t key;
+    double value;
+};
+
+struct clap_audio_buffer_t {
+    float** data32;
+    double** data64;
+    uint32_t channel_count;
+    uint32_t latency;
+    uint64_t constant_mask;
+};
+
+struct clap_process_t {
+    int64_t steady_time;
+    uint32_t frames_count;
+    const void* transport;
+    const clap_audio_buffer_t* audio_inputs;
+    clap_audio_buffer_t* audio_outputs;
+    const clap_input_events_t* in_events;
+    const clap_output_events_t* out_events;
+};
+
+struct clap_input_events_t {
+    void* ctx;
+    uint32_t (*size)(const clap_input_events_t* list);
+    const clap_event_header_t* (*get)(const clap_input_events_t* list, uint32_t index);
+};
+
+struct clap_output_events_t {
+    void* ctx;
+    bool (*try_push)(const clap_output_events_t* list, const clap_event_header_t* event);
+};
+
+struct clap_host_t {
+    clap_version_t clap_version;
+    void* host_data;
+    const char* name;
+    const char* vendor;
+    const char* url;
+    const char* version;
+    const void* (*get_extension)(const clap_host_t* host, const char* extension_id);
+    void (*request_restart)(const clap_host_t* host);
+    void (*request_process)(const clap_host_t* host);
+    void (*request_callback)(const clap_host_t* host);
+};
+
+struct clap_plugin_descriptor_t {
+    clap_version_t clap_version;
+    const char* id;
+    const char* name;
+    const char* vendor;
+    const char* url;
+    const char* manual_url;
+    const char* support_url;
+    const char* version;
+    const char* description;
+    const char* const* features;
+};
+
+struct clap_plugin_t {
+    const clap_plugin_descriptor_t* desc;
+    void* plugin_data;
+    bool (*init)(const clap_plugin_t* plugin);
+    void (*destroy)(const clap_plugin_t* plugin);
+    bool (*activate)(const clap_plugin_t* plugin, double sample_rate,
+                     uint32_t min_frames_count, uint32_t max_frames_count);
+    void (*deactivate)(const clap_plugin_t* plugin);
+    bool (*start_processing)(const clap_plugin_t* plugin);
+    void (*stop_processing)(const clap_plugin_t* plugin);
+    void (*reset)(const clap_plugin_t* plugin);
+    clap_process_status (*process)(const clap_plugin_t* plugin, const clap_process_t* process);
+    const void* (*get_extension)(const clap_plugin_t* plugin, const char* id);
+    void (*on_main_thread)(const clap_plugin_t* plugin);
+};
+
+struct clap_plugin_factory_t {
+    uint32_t (*get_plugin_count)(const clap_plugin_factory_t* factory);
+    const clap_plugin_descriptor_t* (*get_plugin_descriptor)(const clap_plugin_factory_t* factory, uint32_t index);
+    const clap_plugin_t* (*create_plugin)(const clap_plugin_factory_t* factory,
+                                          const clap_host_t* host,
+                                          const char* plugin_id);
+};
+
+struct clap_plugin_entry_t {
+    clap_version_t clap_version;
+    bool (*init)(const char* plugin_path);
+    void (*deinit)();
+    const void* (*get_factory)(const char* factory_id);
+};
+
+struct clap_param_info_t {
+    clap_id id;
+    uint32_t flags;
+    void* cookie;
+    char name[256];
+    char module[1024];
+    double min_value;
+    double max_value;
+    double default_value;
+};
+
+struct clap_plugin_params_t {
+    uint32_t (*count)(const clap_plugin_t* plugin);
+    bool (*get_info)(const clap_plugin_t* plugin, uint32_t param_index, clap_param_info_t* param_info);
+    bool (*get_value)(const clap_plugin_t* plugin, clap_id param_id, double* out_value);
+    bool (*value_to_text)(const clap_plugin_t* plugin, clap_id param_id, double value,
+                          char* out_buffer, uint32_t out_buffer_capacity);
+    bool (*text_to_value)(const clap_plugin_t* plugin, clap_id param_id, const char* param_value_text,
+                          double* out_value);
+    void (*flush)(const clap_plugin_t* plugin, const clap_input_events_t* in, const clap_output_events_t* out);
+};
+
+struct clap_audio_port_info_t {
+    clap_id id;
+    char name[256];
+    uint32_t flags;
+    uint32_t channel_count;
+    const char* port_type;
+    clap_id in_place_pair;
+};
+
+struct clap_plugin_audio_ports_t {
+    uint32_t (*count)(const clap_plugin_t* plugin, bool is_input);
+    bool (*get)(const clap_plugin_t* plugin, uint32_t index, bool is_input, clap_audio_port_info_t* info);
+};
+
+#endif // DONTFLOAT_CLAP_MINIMAL_H

--- a/plugins/clap/dontfloat_clap_pitch_shift.cpp
+++ b/plugins/clap/dontfloat_clap_pitch_shift.cpp
@@ -1,0 +1,424 @@
+#include "clap_minimal.h"
+#include "../core/dontfloat_plugin_core.h"
+
+#include <algorithm>
+#include <atomic>
+#include <charconv>
+#include <cstdio>
+#include <cstring>
+#include <memory>
+#include <string_view>
+#include <system_error>
+
+using Dontfloat::PluginCore::AudioBufferView;
+using Dontfloat::PluginCore::PitchShiftParams;
+using Dontfloat::PluginCore::PitchShiftProcessor;
+
+namespace {
+
+constexpr const char* kPluginId = "com.dontfloat.pitch-shift";
+
+enum ParamId : clap_id {
+    kParamEnabled = 1,
+    kParamPitchSemitones = 2,
+    kParamGrainHz = 3,
+    kParamShape = 4,
+    kParamJitter = 5,
+    kParamWet = 6,
+    kParamPrefilter = 7,
+};
+
+struct ParamDef {
+    ParamId id;
+    const char* name;
+    double minValue;
+    double maxValue;
+    double defaultValue;
+};
+
+constexpr ParamDef kParams[] = {
+    {kParamEnabled, "Enabled", 0.0, 1.0, 0.0},
+    {kParamPitchSemitones, "Pitch", -24.0, 24.0, 0.0},
+    {kParamGrainHz, "Grain Rate", 4.0, 40.0, 8.0},
+    {kParamShape, "Shape", 0.0, 1.0, 0.5},
+    {kParamJitter, "Jitter", 0.0, 1.0, 0.0},
+    {kParamWet, "Wet", 0.0, 1.0, 1.0},
+    {kParamPrefilter, "Prefilter", 0.0, 1.0, 1.0},
+};
+
+struct ClapPitchShift {
+    clap_plugin_t plugin = {};
+    const clap_host_t* host = nullptr;
+    PitchShiftProcessor processor;
+    std::atomic<double> enabled {0.0};
+    std::atomic<double> pitchSemitones {0.0};
+    std::atomic<double> grainHz {8.0};
+    std::atomic<double> shape {0.5};
+    std::atomic<double> jitter {0.0};
+    std::atomic<double> wet {1.0};
+    std::atomic<double> prefilter {1.0};
+};
+
+const char* const kFeatures[] = {
+    "audio-effect",
+    "pitch-shifter",
+    "stereo",
+    nullptr,
+};
+
+const clap_plugin_descriptor_t kDescriptor = {
+    CLAP_VERSION_INIT,
+    kPluginId,
+    "DONTFLOAT Pitch Shift",
+    "DONTFLOAT",
+    "https://github.com/ili4yov-ika/DONTFLOAT",
+    nullptr,
+    nullptr,
+    "0.0.0.1",
+    "Granular pitch shift powered by DONTFLOAT plugin core",
+    kFeatures,
+};
+
+ClapPitchShift* self(const clap_plugin_t* plugin)
+{
+    return plugin ? static_cast<ClapPitchShift*>(plugin->plugin_data) : nullptr;
+}
+
+const ParamDef* findParam(clap_id id)
+{
+    for (const ParamDef& p : kParams) {
+        if (p.id == id) {
+            return &p;
+        }
+    }
+    return nullptr;
+}
+
+double clampParam(const ParamDef& def, double value)
+{
+    return std::clamp(value, def.minValue, def.maxValue);
+}
+
+double getAtomicParam(const ClapPitchShift& s, clap_id id)
+{
+    switch (id) {
+    case kParamEnabled: return s.enabled.load(std::memory_order_relaxed);
+    case kParamPitchSemitones: return s.pitchSemitones.load(std::memory_order_relaxed);
+    case kParamGrainHz: return s.grainHz.load(std::memory_order_relaxed);
+    case kParamShape: return s.shape.load(std::memory_order_relaxed);
+    case kParamJitter: return s.jitter.load(std::memory_order_relaxed);
+    case kParamWet: return s.wet.load(std::memory_order_relaxed);
+    case kParamPrefilter: return s.prefilter.load(std::memory_order_relaxed);
+    default: return 0.0;
+    }
+}
+
+void setAtomicParam(ClapPitchShift& s, clap_id id, double value)
+{
+    const ParamDef* def = findParam(id);
+    if (!def) {
+        return;
+    }
+    value = clampParam(*def, value);
+    switch (id) {
+    case kParamEnabled: s.enabled.store(value, std::memory_order_relaxed); break;
+    case kParamPitchSemitones: s.pitchSemitones.store(value, std::memory_order_relaxed); break;
+    case kParamGrainHz: s.grainHz.store(value, std::memory_order_relaxed); break;
+    case kParamShape: s.shape.store(value, std::memory_order_relaxed); break;
+    case kParamJitter: s.jitter.store(value, std::memory_order_relaxed); break;
+    case kParamWet: s.wet.store(value, std::memory_order_relaxed); break;
+    case kParamPrefilter: s.prefilter.store(value, std::memory_order_relaxed); break;
+    default: break;
+    }
+}
+
+PitchShiftParams snapshotParams(const ClapPitchShift& s)
+{
+    PitchShiftParams p;
+    p.enabled = s.enabled.load(std::memory_order_relaxed) >= 0.5;
+    p.pitchSemitones = float(s.pitchSemitones.load(std::memory_order_relaxed));
+    p.grainHz = float(s.grainHz.load(std::memory_order_relaxed));
+    p.shape = float(s.shape.load(std::memory_order_relaxed));
+    p.jitter = float(s.jitter.load(std::memory_order_relaxed));
+    p.wet = float(s.wet.load(std::memory_order_relaxed));
+    p.prefilter = s.prefilter.load(std::memory_order_relaxed) >= 0.5;
+    return p;
+}
+
+bool pluginInit(const clap_plugin_t*)
+{
+    return true;
+}
+
+void pluginDestroy(const clap_plugin_t* plugin)
+{
+    delete self(plugin);
+}
+
+bool pluginActivate(const clap_plugin_t* plugin, double sampleRate, uint32_t, uint32_t maxFrames)
+{
+    ClapPitchShift* s = self(plugin);
+    if (!s || sampleRate <= 0.0) {
+        return false;
+    }
+    s->processor.prepare(int(sampleRate), int(maxFrames));
+    return true;
+}
+
+void pluginDeactivate(const clap_plugin_t*)
+{
+}
+
+bool pluginStartProcessing(const clap_plugin_t*)
+{
+    return true;
+}
+
+void pluginStopProcessing(const clap_plugin_t*)
+{
+}
+
+void pluginReset(const clap_plugin_t* plugin)
+{
+    if (ClapPitchShift* s = self(plugin)) {
+        s->processor.reset();
+    }
+}
+
+void applyInputEvents(ClapPitchShift& s, const clap_input_events_t* events)
+{
+    if (!events || !events->size || !events->get) {
+        return;
+    }
+    const uint32_t count = events->size(events);
+    for (uint32_t i = 0; i < count; ++i) {
+        const clap_event_header_t* header = events->get(events, i);
+        if (!header || header->space_id != CLAP_CORE_EVENT_SPACE_ID
+            || header->type != CLAP_EVENT_PARAM_VALUE
+            || header->size < sizeof(clap_event_param_value_t)) {
+            continue;
+        }
+        const auto* event = reinterpret_cast<const clap_event_param_value_t*>(header);
+        setAtomicParam(s, event->param_id, event->value);
+    }
+}
+
+clap_process_status pluginProcess(const clap_plugin_t* plugin, const clap_process_t* process)
+{
+    ClapPitchShift* s = self(plugin);
+    if (!s || !process || process->frames_count == 0 || !process->audio_outputs) {
+        return CLAP_PROCESS_ERROR;
+    }
+
+    applyInputEvents(*s, process->in_events);
+    s->processor.setParams(snapshotParams(*s));
+
+    const clap_audio_buffer_t& in = process->audio_inputs ? process->audio_inputs[0] : clap_audio_buffer_t{};
+    clap_audio_buffer_t& out = process->audio_outputs[0];
+    const float* inputPtrs[2] = {
+        (in.data32 && in.channel_count > 0) ? in.data32[0] : nullptr,
+        (in.data32 && in.channel_count > 1) ? in.data32[1] : nullptr,
+    };
+    float* outputPtrs[2] = {
+        (out.data32 && out.channel_count > 0) ? out.data32[0] : nullptr,
+        (out.data32 && out.channel_count > 1) ? out.data32[1] : nullptr,
+    };
+    s->processor.processReplacing(AudioBufferView{
+        inputPtrs,
+        outputPtrs,
+        std::min<int>(int(in.channel_count), 2),
+        std::min<int>(int(out.channel_count), 2),
+        int(process->frames_count),
+    });
+    return CLAP_PROCESS_CONTINUE;
+}
+
+uint32_t paramsCount(const clap_plugin_t*)
+{
+    return uint32_t(sizeof(kParams) / sizeof(kParams[0]));
+}
+
+bool paramsGetInfo(const clap_plugin_t*, uint32_t index, clap_param_info_t* info)
+{
+    if (!info || index >= paramsCount(nullptr)) {
+        return false;
+    }
+    const ParamDef& def = kParams[index];
+    *info = {};
+    info->id = def.id;
+    info->flags = CLAP_PARAM_IS_AUTOMATABLE;
+    std::strncpy(info->name, def.name, sizeof(info->name) - 1);
+    std::strncpy(info->module, "Pitch Shift", sizeof(info->module) - 1);
+    info->min_value = def.minValue;
+    info->max_value = def.maxValue;
+    info->default_value = def.defaultValue;
+    return true;
+}
+
+bool paramsGetValue(const clap_plugin_t* plugin, clap_id paramId, double* outValue)
+{
+    ClapPitchShift* s = self(plugin);
+    if (!s || !outValue || !findParam(paramId)) {
+        return false;
+    }
+    *outValue = getAtomicParam(*s, paramId);
+    return true;
+}
+
+bool paramsValueToText(const clap_plugin_t*, clap_id paramId, double value,
+                       char* outBuffer, uint32_t outBufferCapacity)
+{
+    if (!outBuffer || outBufferCapacity == 0 || !findParam(paramId)) {
+        return false;
+    }
+    if (paramId == kParamEnabled || paramId == kParamPrefilter) {
+        const char* text = value >= 0.5 ? "On" : "Off";
+        std::strncpy(outBuffer, text, outBufferCapacity - 1);
+        outBuffer[outBufferCapacity - 1] = '\0';
+        return true;
+    }
+    const int written = std::snprintf(outBuffer, outBufferCapacity, "%.3f", value);
+    return written > 0;
+}
+
+bool paramsTextToValue(const clap_plugin_t*, clap_id paramId, const char* text, double* outValue)
+{
+    const ParamDef* def = findParam(paramId);
+    if (!def || !text || !outValue) {
+        return false;
+    }
+    double value = def->defaultValue;
+    const std::string_view view(text);
+    const auto result = std::from_chars(view.data(), view.data() + view.size(), value);
+    if (result.ec != std::errc()) {
+        return false;
+    }
+    *outValue = clampParam(*def, value);
+    return true;
+}
+
+void paramsFlush(const clap_plugin_t* plugin, const clap_input_events_t* in, const clap_output_events_t*)
+{
+    if (ClapPitchShift* s = self(plugin)) {
+        applyInputEvents(*s, in);
+    }
+}
+
+uint32_t audioPortsCount(const clap_plugin_t*, bool)
+{
+    return 1;
+}
+
+bool audioPortsGet(const clap_plugin_t*, uint32_t index, bool isInput, clap_audio_port_info_t* info)
+{
+    if (!info || index > 0) {
+        return false;
+    }
+    *info = {};
+    info->id = isInput ? 0 : 1;
+    info->flags = CLAP_AUDIO_PORT_IS_MAIN;
+    info->channel_count = 2;
+    info->port_type = CLAP_PORT_STEREO;
+    info->in_place_pair = isInput ? 1 : 0;
+    std::strncpy(info->name, isInput ? "Input" : "Output", sizeof(info->name) - 1);
+    return true;
+}
+
+const clap_plugin_params_t kParamsExtension = {
+    paramsCount,
+    paramsGetInfo,
+    paramsGetValue,
+    paramsValueToText,
+    paramsTextToValue,
+    paramsFlush,
+};
+
+const clap_plugin_audio_ports_t kAudioPortsExtension = {
+    audioPortsCount,
+    audioPortsGet,
+};
+
+const void* pluginGetExtension(const clap_plugin_t*, const char* id)
+{
+    if (!id) {
+        return nullptr;
+    }
+    if (std::strcmp(id, CLAP_EXT_PARAMS) == 0) {
+        return &kParamsExtension;
+    }
+    if (std::strcmp(id, CLAP_EXT_AUDIO_PORTS) == 0) {
+        return &kAudioPortsExtension;
+    }
+    return nullptr;
+}
+
+void pluginOnMainThread(const clap_plugin_t*)
+{
+}
+
+uint32_t factoryGetPluginCount(const clap_plugin_factory_t*)
+{
+    return 1;
+}
+
+const clap_plugin_descriptor_t* factoryGetPluginDescriptor(const clap_plugin_factory_t*, uint32_t index)
+{
+    return index == 0 ? &kDescriptor : nullptr;
+}
+
+const clap_plugin_t* factoryCreatePlugin(const clap_plugin_factory_t*, const clap_host_t* host, const char* pluginId)
+{
+    if (!pluginId || std::strcmp(pluginId, kPluginId) != 0) {
+        return nullptr;
+    }
+
+    auto* s = new ClapPitchShift();
+    s->host = host;
+    s->plugin.desc = &kDescriptor;
+    s->plugin.plugin_data = s;
+    s->plugin.init = pluginInit;
+    s->plugin.destroy = pluginDestroy;
+    s->plugin.activate = pluginActivate;
+    s->plugin.deactivate = pluginDeactivate;
+    s->plugin.start_processing = pluginStartProcessing;
+    s->plugin.stop_processing = pluginStopProcessing;
+    s->plugin.reset = pluginReset;
+    s->plugin.process = pluginProcess;
+    s->plugin.get_extension = pluginGetExtension;
+    s->plugin.on_main_thread = pluginOnMainThread;
+    return &s->plugin;
+}
+
+const clap_plugin_factory_t kFactory = {
+    factoryGetPluginCount,
+    factoryGetPluginDescriptor,
+    factoryCreatePlugin,
+};
+
+bool entryInit(const char*)
+{
+    return true;
+}
+
+void entryDeinit()
+{
+}
+
+const void* entryGetFactory(const char* factoryId)
+{
+    if (factoryId && std::strcmp(factoryId, CLAP_PLUGIN_FACTORY_ID) == 0) {
+        return &kFactory;
+    }
+    return nullptr;
+}
+
+} // namespace
+
+extern "C" {
+CLAP_EXPORT extern const clap_plugin_entry_t clap_entry = {
+    CLAP_VERSION_INIT,
+    entryInit,
+    entryDeinit,
+    entryGetFactory,
+};
+}

--- a/plugins/clap/tests/clap_pitch_shift_smoke_test.cpp
+++ b/plugins/clap/tests/clap_pitch_shift_smoke_test.cpp
@@ -1,0 +1,142 @@
+#include "../clap_minimal.h"
+
+#include <cmath>
+#include <cstring>
+#include <iostream>
+#include <vector>
+
+extern "C" {
+extern const clap_plugin_entry_t clap_entry;
+}
+
+namespace {
+
+struct EventList {
+    clap_input_events_t iface {};
+    std::vector<clap_event_param_value_t> events;
+};
+
+uint32_t eventListSize(const clap_input_events_t* list)
+{
+    const auto* self = static_cast<const EventList*>(list->ctx);
+    return uint32_t(self->events.size());
+}
+
+const clap_event_header_t* eventListGet(const clap_input_events_t* list, uint32_t index)
+{
+    const auto* self = static_cast<const EventList*>(list->ctx);
+    if (index >= self->events.size()) {
+        return nullptr;
+    }
+    return &self->events[index].header;
+}
+
+clap_event_param_value_t makeParamEvent(clap_id id, double value)
+{
+    clap_event_param_value_t event {};
+    event.header.size = sizeof(clap_event_param_value_t);
+    event.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
+    event.header.type = CLAP_EVENT_PARAM_VALUE;
+    event.param_id = id;
+    event.value = value;
+    return event;
+}
+
+bool isFinite(const std::vector<float>& values)
+{
+    for (float value : values) {
+        if (!std::isfinite(value)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+} // namespace
+
+int main()
+{
+    if (!clap_entry.init("dontfloat_pitch_shift.clap")) {
+        std::cerr << "clap_entry.init failed\n";
+        return 1;
+    }
+
+    const auto* factory = static_cast<const clap_plugin_factory_t*>(
+        clap_entry.get_factory(CLAP_PLUGIN_FACTORY_ID));
+    if (!factory || factory->get_plugin_count(factory) != 1) {
+        std::cerr << "factory unavailable\n";
+        return 1;
+    }
+
+    const clap_plugin_descriptor_t* descriptor = factory->get_plugin_descriptor(factory, 0);
+    if (!descriptor || std::strcmp(descriptor->id, "com.dontfloat.pitch-shift") != 0) {
+        std::cerr << "descriptor mismatch\n";
+        return 1;
+    }
+
+    clap_host_t host {};
+    host.clap_version = CLAP_VERSION_INIT;
+    host.name = "DONTFLOAT smoke host";
+
+    const clap_plugin_t* plugin = factory->create_plugin(factory, &host, descriptor->id);
+    if (!plugin || !plugin->init(plugin) || !plugin->activate(plugin, 44100.0, 64, 512)
+        || !plugin->start_processing(plugin)) {
+        std::cerr << "plugin lifecycle failed\n";
+        return 1;
+    }
+
+    const auto* params = static_cast<const clap_plugin_params_t*>(
+        plugin->get_extension(plugin, CLAP_EXT_PARAMS));
+    const auto* audioPorts = static_cast<const clap_plugin_audio_ports_t*>(
+        plugin->get_extension(plugin, CLAP_EXT_AUDIO_PORTS));
+    if (!params || !audioPorts || params->count(plugin) != 7
+        || audioPorts->count(plugin, true) != 1 || audioPorts->count(plugin, false) != 1) {
+        std::cerr << "extensions unavailable\n";
+        return 1;
+    }
+
+    EventList eventList;
+    eventList.iface.ctx = &eventList;
+    eventList.iface.size = eventListSize;
+    eventList.iface.get = eventListGet;
+    eventList.events.push_back(makeParamEvent(1, 1.0));   // Enabled
+    eventList.events.push_back(makeParamEvent(2, 7.0));   // Pitch semitones
+    eventList.events.push_back(makeParamEvent(6, 0.75));  // Wet
+
+    constexpr uint32_t frames = 256;
+    std::vector<float> inL(frames);
+    std::vector<float> inR(frames);
+    std::vector<float> outL(frames, 0.0f);
+    std::vector<float> outR(frames, 0.0f);
+    for (uint32_t i = 0; i < frames; ++i) {
+        inL[i] = std::sin(float(i) * 0.03f);
+        inR[i] = std::cos(float(i) * 0.04f);
+    }
+
+    float* inputPtrs[] = {inL.data(), inR.data()};
+    float* outputPtrs[] = {outL.data(), outR.data()};
+    clap_audio_buffer_t input {};
+    input.data32 = inputPtrs;
+    input.channel_count = 2;
+    clap_audio_buffer_t output {};
+    output.data32 = outputPtrs;
+    output.channel_count = 2;
+
+    clap_process_t process {};
+    process.frames_count = frames;
+    process.audio_inputs = &input;
+    process.audio_outputs = &output;
+    process.in_events = &eventList.iface;
+
+    const clap_process_status status = plugin->process(plugin, &process);
+    plugin->stop_processing(plugin);
+    plugin->deactivate(plugin);
+    plugin->destroy(plugin);
+    clap_entry.deinit();
+
+    if (status != CLAP_PROCESS_CONTINUE || !isFinite(outL) || !isFinite(outR)) {
+        std::cerr << "process failed\n";
+        return 1;
+    }
+    return 0;
+}

--- a/plugins/core/README.md
+++ b/plugins/core/README.md
@@ -1,0 +1,72 @@
+# DONTFLOAT Plugin Core
+
+`plugins/core` содержит общее DSP-ядро для plugin targets. Сейчас реализован
+MVP для granular pitch shift, который используется CLAP-обёрткой.
+
+## Назначение
+
+- Дать плагинам единый API обработки аудиобуферов и параметров.
+- Отделить DSP от `MainWindow`, `WaveformView`, `PitchGridWidget`,
+  `QMediaPlayer`, `QSettings` и других UI/runtime-зависимостей.
+- Сохранить совпадение поведения с текущими возможностями приложения:
+  time stretch, pitch shift, BPM/key analysis.
+
+## Что можно переиспользовать
+
+| Возможность | Текущий код |
+|---|---|
+| Time stretch | `TimeStretchProcessor`, `RubberBandOffline` |
+| Pitch shift | `GranularEngine` (`include/granularpitchshifter_engine.h`) |
+| BPM / beat grid | `BPMAnalyzer` |
+| Тональность | `KeyAnalyzer` |
+| Метки stretch | `MarkerData`, расчёт сегментов в `TimeStretchProcessor` |
+
+## Реализованный API
+
+Core оперирует простыми структурами:
+
+```cpp
+struct AudioBufferView {
+    const float* const* inputs;
+    float* const* outputs;
+    int inputChannelCount;
+    int outputChannelCount;
+    int frameCount;
+};
+
+struct PitchShiftParams {
+    bool enabled;
+    float pitchSemitones;
+    float grainHz;
+    float shape;
+    float jitter;
+    float wet;
+    bool prefilter;
+};
+```
+
+Qt-типы (`QVector`, `QString`) допустимы в текущем приложении, но для plugin
+core лучше перейти на `std::vector`, `std::string` и plain structs.
+
+Текущие файлы:
+
+- `dontfloat_plugin_core.h`
+- `dontfloat_plugin_core.cpp`
+- `tests/plugin_core_pitch_shift_test.cpp`
+
+Текущий CMake target: `dontfloat_plugin_core`.
+
+## Realtime-ограничения
+
+- Не выделять память в audio callback.
+- Не обращаться к файловой системе из audio callback.
+- Не использовать `qDebug`, `std::cout`, исключения и блокирующие mutex в
+  горячем пути.
+- Offline-алгоритмы (Rubber Band R3 stretch) отделять от realtime pitch shift.
+
+## План
+
+1. Расширить smoke-тесты до сравнения с существующим Qt API.
+2. Добавить state serialization для параметров.
+3. Добавить offline adapters для будущего time stretch.
+4. Подключать core из `plugins/vst3` и `plugins/lv2` после CLAP MVP.

--- a/plugins/core/dontfloat_plugin_core.cpp
+++ b/plugins/core/dontfloat_plugin_core.cpp
@@ -1,0 +1,155 @@
+#include "dontfloat_plugin_core.h"
+
+#include "../../include/granularpitchshifter_engine.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace Dontfloat::PluginCore {
+namespace {
+
+float clampFloat(float value, float minValue, float maxValue)
+{
+    if (!std::isfinite(value)) {
+        return minValue;
+    }
+    return std::clamp(value, minValue, maxValue);
+}
+
+void copyOrClear(const AudioBufferView& buffer)
+{
+    const int outputChannels = std::max(0, buffer.outputChannelCount);
+    const int inputChannels = std::max(0, buffer.inputChannelCount);
+
+    for (int ch = 0; ch < outputChannels; ++ch) {
+        float* out = buffer.outputs ? buffer.outputs[ch] : nullptr;
+        if (!out) {
+            continue;
+        }
+
+        const float* in = (buffer.inputs && ch < inputChannels) ? buffer.inputs[ch] : nullptr;
+        if (in) {
+            if (in != out) {
+                std::copy(in, in + buffer.frameCount, out);
+            }
+        } else {
+            std::fill(out, out + buffer.frameCount, 0.0f);
+        }
+    }
+}
+
+} // namespace
+
+class PitchShiftProcessor::Impl {
+public:
+    GranularEngine::Engine engine;
+};
+
+PitchShiftProcessor::PitchShiftProcessor()
+    : impl_(new Impl())
+{
+}
+
+PitchShiftProcessor::~PitchShiftProcessor()
+{
+    delete impl_;
+}
+
+void PitchShiftProcessor::prepare(int sampleRate, int maxBlockSize)
+{
+    sampleRate_ = std::max(1, sampleRate);
+    maxBlockSize_ = std::max(0, maxBlockSize);
+    reset();
+    prepared_ = true;
+}
+
+void PitchShiftProcessor::reset()
+{
+    const int ringReferenceSamples = std::max(sampleRate_, maxBlockSize_);
+    impl_->engine.init(sampleRate_, ringReferenceSamples);
+}
+
+void PitchShiftProcessor::setParams(const PitchShiftParams& params)
+{
+    params_ = sanitizePitchShiftParams(params);
+}
+
+void PitchShiftProcessor::processReplacing(const AudioBufferView& buffer)
+{
+    if (!buffer.outputs || buffer.outputChannelCount <= 0 || buffer.frameCount <= 0) {
+        return;
+    }
+
+    if (!prepared_) {
+        prepare(sampleRate_, buffer.frameCount);
+    }
+
+    const PitchShiftParams p = sanitizePitchShiftParams(params_);
+    if (!p.enabled || std::abs(p.pitchSemitones) < 0.0001f || p.wet <= 0.0f) {
+        copyOrClear(buffer);
+        return;
+    }
+
+    const float dry = 1.0f - p.wet;
+    const double pitchSpeed = std::exp2(p.pitchSemitones / 12.0);
+
+    for (int i = 0; i < buffer.frameCount; ++i) {
+        const float inL = (buffer.inputs && buffer.inputChannelCount > 0 && buffer.inputs[0])
+            ? buffer.inputs[0][i]
+            : 0.0f;
+        const float inR = (buffer.inputs && buffer.inputChannelCount > 1 && buffer.inputs[1])
+            ? buffer.inputs[1][i]
+            : inL;
+
+        float shiftedL = 0.0f;
+        float shiftedR = 0.0f;
+        impl_->engine.process(inL, inR, p.grainHz, pitchSpeed, p.shape, p.jitter,
+                              p.prefilter, shiftedL, shiftedR);
+
+        if (buffer.outputs[0]) {
+            buffer.outputs[0][i] = dry * inL + p.wet * shiftedL;
+        }
+        if (buffer.outputChannelCount > 1 && buffer.outputs[1]) {
+            buffer.outputs[1][i] = dry * inR + p.wet * shiftedR;
+        }
+        for (int ch = 2; ch < buffer.outputChannelCount; ++ch) {
+            if (!buffer.outputs[ch]) {
+                continue;
+            }
+            const float* in = (buffer.inputs && ch < buffer.inputChannelCount) ? buffer.inputs[ch] : nullptr;
+            buffer.outputs[ch][i] = in ? in[i] : 0.0f;
+        }
+    }
+}
+
+PitchShiftParams sanitizePitchShiftParams(const PitchShiftParams& params)
+{
+    PitchShiftParams out = params;
+    out.pitchSemitones = clampFloat(out.pitchSemitones, -24.0f, 24.0f);
+    out.grainHz = clampFloat(out.grainHz, 4.0f, 40.0f);
+    out.shape = clampFloat(out.shape, 0.0f, 1.0f);
+    out.jitter = clampFloat(out.jitter, 0.0f, 1.0f);
+    out.wet = clampFloat(out.wet, 0.0f, 1.0f);
+    return out;
+}
+
+bool isFiniteBuffer(const AudioBufferView& buffer)
+{
+    if (!buffer.outputs || buffer.outputChannelCount <= 0 || buffer.frameCount < 0) {
+        return false;
+    }
+    for (int ch = 0; ch < buffer.outputChannelCount; ++ch) {
+        const float* out = buffer.outputs[ch];
+        if (!out) {
+            continue;
+        }
+        for (int i = 0; i < buffer.frameCount; ++i) {
+            if (!std::isfinite(out[i])) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+} // namespace Dontfloat::PluginCore

--- a/plugins/core/dontfloat_plugin_core.h
+++ b/plugins/core/dontfloat_plugin_core.h
@@ -1,0 +1,61 @@
+#ifndef DONTFLOAT_PLUGIN_CORE_H
+#define DONTFLOAT_PLUGIN_CORE_H
+
+#include <cstdint>
+
+namespace Dontfloat::PluginCore {
+
+struct AudioBufferView {
+    const float* const* inputs = nullptr;
+    float* const* outputs = nullptr;
+    int inputChannelCount = 0;
+    int outputChannelCount = 0;
+    int frameCount = 0;
+};
+
+struct PitchShiftParams {
+    bool enabled = false;
+    float pitchSemitones = 0.0f;
+    float grainHz = 8.0f;
+    float shape = 0.5f;
+    float jitter = 0.0f;
+    float wet = 1.0f;
+    bool prefilter = true;
+};
+
+class PitchShiftProcessor {
+public:
+    PitchShiftProcessor();
+    ~PitchShiftProcessor();
+
+    PitchShiftProcessor(const PitchShiftProcessor&) = delete;
+    PitchShiftProcessor& operator=(const PitchShiftProcessor&) = delete;
+
+    void prepare(int sampleRate, int maxBlockSize);
+    void reset();
+
+    void setParams(const PitchShiftParams& params);
+    const PitchShiftParams& params() const { return params_; }
+
+    void processReplacing(const AudioBufferView& buffer);
+
+    int sampleRate() const { return sampleRate_; }
+    int maxBlockSize() const { return maxBlockSize_; }
+    bool isPrepared() const { return prepared_; }
+
+private:
+    class Impl;
+
+    PitchShiftParams params_;
+    Impl* impl_ = nullptr;
+    int sampleRate_ = 44100;
+    int maxBlockSize_ = 0;
+    bool prepared_ = false;
+};
+
+PitchShiftParams sanitizePitchShiftParams(const PitchShiftParams& params);
+bool isFiniteBuffer(const AudioBufferView& buffer);
+
+} // namespace Dontfloat::PluginCore
+
+#endif // DONTFLOAT_PLUGIN_CORE_H

--- a/plugins/core/tests/plugin_core_pitch_shift_test.cpp
+++ b/plugins/core/tests/plugin_core_pitch_shift_test.cpp
@@ -1,0 +1,123 @@
+#include "../dontfloat_plugin_core.h"
+
+#include <cmath>
+#include <iostream>
+#include <vector>
+
+using Dontfloat::PluginCore::AudioBufferView;
+using Dontfloat::PluginCore::PitchShiftParams;
+using Dontfloat::PluginCore::PitchShiftProcessor;
+using Dontfloat::PluginCore::isFiniteBuffer;
+
+namespace {
+
+bool nearlyEqual(float a, float b, float eps = 1.0e-6f)
+{
+    return std::abs(a - b) <= eps;
+}
+
+bool testBypassCopiesInput()
+{
+    constexpr int frames = 128;
+    std::vector<float> inL(frames);
+    std::vector<float> inR(frames);
+    std::vector<float> outL(frames, -1.0f);
+    std::vector<float> outR(frames, -1.0f);
+
+    for (int i = 0; i < frames; ++i) {
+        inL[i] = std::sin(float(i) * 0.05f);
+        inR[i] = std::cos(float(i) * 0.05f);
+    }
+
+    const float* inputs[] = {inL.data(), inR.data()};
+    float* outputs[] = {outL.data(), outR.data()};
+
+    PitchShiftProcessor processor;
+    processor.prepare(44100, frames);
+    processor.setParams(PitchShiftParams{});
+    processor.processReplacing(AudioBufferView{inputs, outputs, 2, 2, frames});
+
+    for (int i = 0; i < frames; ++i) {
+        if (!nearlyEqual(outL[i], inL[i]) || !nearlyEqual(outR[i], inR[i])) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool testEnabledProducesFiniteStereo()
+{
+    constexpr int frames = 512;
+    std::vector<float> inL(frames);
+    std::vector<float> inR(frames);
+    std::vector<float> outL(frames, 0.0f);
+    std::vector<float> outR(frames, 0.0f);
+
+    for (int i = 0; i < frames; ++i) {
+        inL[i] = std::sin(float(i) * 0.03f);
+        inR[i] = std::sin(float(i) * 0.07f);
+    }
+
+    const float* inputs[] = {inL.data(), inR.data()};
+    float* outputs[] = {outL.data(), outR.data()};
+
+    PitchShiftParams params;
+    params.enabled = true;
+    params.pitchSemitones = 7.0f;
+    params.grainHz = 12.0f;
+    params.shape = 0.5f;
+    params.jitter = 0.1f;
+    params.wet = 0.75f;
+    params.prefilter = true;
+
+    PitchShiftProcessor processor;
+    processor.prepare(44100, frames);
+    processor.setParams(params);
+    processor.processReplacing(AudioBufferView{inputs, outputs, 2, 2, frames});
+
+    return isFiniteBuffer(AudioBufferView{inputs, outputs, 2, 2, frames});
+}
+
+bool testMonoToStereo()
+{
+    constexpr int frames = 128;
+    std::vector<float> in(frames, 0.25f);
+    std::vector<float> outL(frames, 0.0f);
+    std::vector<float> outR(frames, 0.0f);
+
+    const float* inputs[] = {in.data()};
+    float* outputs[] = {outL.data(), outR.data()};
+
+    PitchShiftProcessor processor;
+    processor.prepare(48000, frames);
+    PitchShiftParams params;
+    params.enabled = false;
+    processor.setParams(params);
+    processor.processReplacing(AudioBufferView{inputs, outputs, 1, 2, frames});
+
+    for (int i = 0; i < frames; ++i) {
+        if (!nearlyEqual(outL[i], in[i]) || !nearlyEqual(outR[i], 0.0f)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+} // namespace
+
+int main()
+{
+    if (!testBypassCopiesInput()) {
+        std::cerr << "testBypassCopiesInput failed\n";
+        return 1;
+    }
+    if (!testEnabledProducesFiniteStereo()) {
+        std::cerr << "testEnabledProducesFiniteStereo failed\n";
+        return 1;
+    }
+    if (!testMonoToStereo()) {
+        std::cerr << "testMonoToStereo failed\n";
+        return 1;
+    }
+    return 0;
+}

--- a/plugins/lv2/README.md
+++ b/plugins/lv2/README.md
@@ -1,0 +1,89 @@
+# DONTFLOAT LV2
+
+`plugins/lv2` содержит начальную LV2-реализацию pitch shift плагина DONTFLOAT.
+
+## Назначение
+
+LV2 стоит рассматривать как Linux-first формат после появления стабильного
+`plugins/core`. Основной сценарий — загрузка в Linux DAW и plugin hosts,
+которые используют `.ttl` manifests.
+
+## Возможные плагины
+
+### DONTFLOAT Pitch Shift
+- Реализован как `dontfloat_pitch_shift_lv2`.
+- Основа: `plugins/core` + `GranularEngine`.
+- Realtime-параметры: enabled, pitch, grain rate, shape, jitter, wet, prefilter.
+
+### DONTFLOAT Analyzer
+- Возможен как utility-плагин, если host workflow позволяет отображать
+  результаты анализа BPM/тональности.
+- Основа: `BPMAnalyzer`, `KeyAnalyzer`.
+- Не должен выполнять тяжёлый анализ в audio callback.
+
+## Текущая структура
+
+```text
+plugins/lv2/
+├── README.md
+├── lv2_minimal.h
+├── dontfloat_lv2_pitch_shift.cpp
+├── dontfloat_pitch_shift.lv2/
+│   ├── manifest.ttl
+│   └── dontfloat_pitch_shift.ttl
+```
+
+Файлы `.ttl` должны описывать URI плагина, порты аудио, параметры, значения по
+умолчанию и путь к shared library.
+
+## Правила реализации
+
+- DSP находится в `plugins/core`; LV2-слой только адаптирует API хоста.
+- Port indices должны быть стабильными.
+- Realtime callback не выделяет память и не вызывает тяжёлый анализ.
+- State/preset формат должен быть совместим между версиями.
+- GUI лучше отложить: начать с generic UI хоста.
+
+## Сборка
+
+LV2 target подключён к CMake за флагами:
+
+```cmake
+option(DONTFLOAT_BUILD_PLUGINS "Build DAW plugins" OFF)
+option(DONTFLOAT_BUILD_LV2 "Build LV2 plugin target when plugins are enabled" ON)
+```
+
+Сборка:
+
+```powershell
+cmake -S . -B build/plugins -DDONTFLOAT_BUILD_PLUGINS=ON -DDONTFLOAT_BUILD_LV2=ON
+cmake --build build/plugins --target dontfloat_pitch_shift_lv2 lv2_pitch_shift_smoke_test
+ctest --test-dir build/plugins -R lv2_pitch_shift_smoke_test --output-on-failure
+```
+
+В build-каталоге создаётся bundle:
+
+```text
+plugins/lv2/dontfloat_pitch_shift.lv2/
+├── dontfloat_pitch_shift.dll|so|dylib
+├── manifest.ttl
+└── dontfloat_pitch_shift.ttl
+```
+
+Для Linux packaging понадобится установка bundle в стандартный путь:
+
+```text
+~/.lv2/
+/usr/lib/lv2/
+/usr/local/lib/lv2/
+```
+
+CMake install rule кладёт bundle в
+`${CMAKE_INSTALL_LIBDIR}/lv2/dontfloat_pitch_shift.lv2`.
+
+## Проверка
+
+1. Проверить `.ttl` через `lv2_validate`, если доступен.
+2. Загрузить bundle в тестовый LV2 host.
+3. Сравнить результат обработки с `plugins/core`.
+4. Проверить сохранение state/preset в DAW.

--- a/plugins/lv2/dontfloat_lv2_pitch_shift.cpp
+++ b/plugins/lv2/dontfloat_lv2_pitch_shift.cpp
@@ -1,0 +1,156 @@
+#include "lv2_minimal.h"
+#include "../core/dontfloat_plugin_core.h"
+
+#include <algorithm>
+#include <cstdint>
+
+using Dontfloat::PluginCore::AudioBufferView;
+using Dontfloat::PluginCore::PitchShiftParams;
+using Dontfloat::PluginCore::PitchShiftProcessor;
+
+namespace {
+
+constexpr const char* kPluginUri = "https://github.com/ili4yov-ika/DONTFLOAT/plugins/pitch-shift";
+
+enum PortIndex : uint32_t {
+    kPortAudioInL = 0,
+    kPortAudioInR,
+    kPortAudioOutL,
+    kPortAudioOutR,
+    kPortEnabled,
+    kPortPitchSemitones,
+    kPortGrainHz,
+    kPortShape,
+    kPortJitter,
+    kPortWet,
+    kPortPrefilter,
+};
+
+struct Lv2PitchShift {
+    PitchShiftProcessor processor;
+
+    const float* inL = nullptr;
+    const float* inR = nullptr;
+    float* outL = nullptr;
+    float* outR = nullptr;
+
+    const float* enabled = nullptr;
+    const float* pitchSemitones = nullptr;
+    const float* grainHz = nullptr;
+    const float* shape = nullptr;
+    const float* jitter = nullptr;
+    const float* wet = nullptr;
+    const float* prefilter = nullptr;
+
+    int sampleRate = 44100;
+};
+
+float readControl(const float* value, float fallback)
+{
+    return value ? *value : fallback;
+}
+
+PitchShiftParams readParams(const Lv2PitchShift& self)
+{
+    PitchShiftParams params;
+    params.enabled = readControl(self.enabled, 0.0f) >= 0.5f;
+    params.pitchSemitones = readControl(self.pitchSemitones, 0.0f);
+    params.grainHz = readControl(self.grainHz, 8.0f);
+    params.shape = readControl(self.shape, 0.5f);
+    params.jitter = readControl(self.jitter, 0.0f);
+    params.wet = readControl(self.wet, 1.0f);
+    params.prefilter = readControl(self.prefilter, 1.0f) >= 0.5f;
+    return params;
+}
+
+LV2_Handle instantiate(const LV2_Descriptor*, double sampleRate, const char*, const LV2_Feature* const*)
+{
+    auto* self = new Lv2PitchShift();
+    self->sampleRate = std::max(1, int(sampleRate));
+    self->processor.prepare(self->sampleRate, 4096);
+    return self;
+}
+
+void connectPort(LV2_Handle instance, uint32_t port, void* data)
+{
+    auto* self = static_cast<Lv2PitchShift*>(instance);
+    if (!self) {
+        return;
+    }
+
+    switch (port) {
+    case kPortAudioInL: self->inL = static_cast<const float*>(data); break;
+    case kPortAudioInR: self->inR = static_cast<const float*>(data); break;
+    case kPortAudioOutL: self->outL = static_cast<float*>(data); break;
+    case kPortAudioOutR: self->outR = static_cast<float*>(data); break;
+    case kPortEnabled: self->enabled = static_cast<const float*>(data); break;
+    case kPortPitchSemitones: self->pitchSemitones = static_cast<const float*>(data); break;
+    case kPortGrainHz: self->grainHz = static_cast<const float*>(data); break;
+    case kPortShape: self->shape = static_cast<const float*>(data); break;
+    case kPortJitter: self->jitter = static_cast<const float*>(data); break;
+    case kPortWet: self->wet = static_cast<const float*>(data); break;
+    case kPortPrefilter: self->prefilter = static_cast<const float*>(data); break;
+    default: break;
+    }
+}
+
+void activate(LV2_Handle instance)
+{
+    if (auto* self = static_cast<Lv2PitchShift*>(instance)) {
+        self->processor.reset();
+    }
+}
+
+void run(LV2_Handle instance, uint32_t sampleCount)
+{
+    auto* self = static_cast<Lv2PitchShift*>(instance);
+    if (!self || sampleCount == 0) {
+        return;
+    }
+
+    self->processor.setParams(readParams(*self));
+
+    const float* inputs[] = {self->inL, self->inR ? self->inR : self->inL};
+    float* outputs[] = {self->outL, self->outR};
+    self->processor.processReplacing(AudioBufferView{
+        inputs,
+        outputs,
+        2,
+        self->outR ? 2 : 1,
+        int(sampleCount),
+    });
+}
+
+void deactivate(LV2_Handle)
+{
+}
+
+void cleanup(LV2_Handle instance)
+{
+    delete static_cast<Lv2PitchShift*>(instance);
+}
+
+const void* extensionData(const char*)
+{
+    return nullptr;
+}
+
+const LV2_Descriptor kDescriptor = {
+    kPluginUri,
+    instantiate,
+    connectPort,
+    activate,
+    run,
+    deactivate,
+    cleanup,
+    extensionData,
+};
+
+} // namespace
+
+extern "C" {
+LV2_SYMBOL_EXPORT const LV2_Descriptor* lv2_descriptor(uint32_t index)
+{
+    return index == 0 ? &kDescriptor : nullptr;
+}
+}

--- a/plugins/lv2/dontfloat_pitch_shift.lv2/dontfloat_pitch_shift.ttl
+++ b/plugins/lv2/dontfloat_pitch_shift.lv2/dontfloat_pitch_shift.ttl
@@ -1,0 +1,103 @@
+@prefix doap: <http://usefulinc.com/ns/doap#> .
+@prefix lv2: <http://lv2plug.in/ns/lv2core#> .
+@prefix pprops: <http://lv2plug.in/ns/ext/port-props#> .
+@prefix units: <http://lv2plug.in/ns/extensions/units#> .
+
+<https://github.com/ili4yov-ika/DONTFLOAT/plugins/pitch-shift>
+    a lv2:Plugin ,
+      lv2:PitchPlugin ;
+    doap:name "DONTFLOAT Pitch Shift" ;
+    doap:license <https://www.gnu.org/licenses/gpl-3.0.html> ;
+    lv2:port [
+        a lv2:AudioPort ,
+          lv2:InputPort ;
+        lv2:index 0 ;
+        lv2:symbol "in_l" ;
+        lv2:name "Input L"
+    ] , [
+        a lv2:AudioPort ,
+          lv2:InputPort ;
+        lv2:index 1 ;
+        lv2:symbol "in_r" ;
+        lv2:name "Input R"
+    ] , [
+        a lv2:AudioPort ,
+          lv2:OutputPort ;
+        lv2:index 2 ;
+        lv2:symbol "out_l" ;
+        lv2:name "Output L"
+    ] , [
+        a lv2:AudioPort ,
+          lv2:OutputPort ;
+        lv2:index 3 ;
+        lv2:symbol "out_r" ;
+        lv2:name "Output R"
+    ] , [
+        a lv2:ControlPort ,
+          lv2:InputPort ;
+        lv2:index 4 ;
+        lv2:symbol "enabled" ;
+        lv2:name "Enabled" ;
+        lv2:default 0 ;
+        lv2:minimum 0 ;
+        lv2:maximum 1 ;
+        lv2:portProperty lv2:toggled
+    ] , [
+        a lv2:ControlPort ,
+          lv2:InputPort ;
+        lv2:index 5 ;
+        lv2:symbol "pitch" ;
+        lv2:name "Pitch" ;
+        lv2:default 0 ;
+        lv2:minimum -24 ;
+        lv2:maximum 24 ;
+        units:unit units:semitone12TET
+    ] , [
+        a lv2:ControlPort ,
+          lv2:InputPort ;
+        lv2:index 6 ;
+        lv2:symbol "grain_hz" ;
+        lv2:name "Grain Rate" ;
+        lv2:default 8 ;
+        lv2:minimum 4 ;
+        lv2:maximum 40 ;
+        units:unit units:hz
+    ] , [
+        a lv2:ControlPort ,
+          lv2:InputPort ;
+        lv2:index 7 ;
+        lv2:symbol "shape" ;
+        lv2:name "Shape" ;
+        lv2:default 0.5 ;
+        lv2:minimum 0 ;
+        lv2:maximum 1
+    ] , [
+        a lv2:ControlPort ,
+          lv2:InputPort ;
+        lv2:index 8 ;
+        lv2:symbol "jitter" ;
+        lv2:name "Jitter" ;
+        lv2:default 0 ;
+        lv2:minimum 0 ;
+        lv2:maximum 1
+    ] , [
+        a lv2:ControlPort ,
+          lv2:InputPort ;
+        lv2:index 9 ;
+        lv2:symbol "wet" ;
+        lv2:name "Wet" ;
+        lv2:default 1 ;
+        lv2:minimum 0 ;
+        lv2:maximum 1 ;
+        lv2:portProperty pprops:hasStrictBounds
+    ] , [
+        a lv2:ControlPort ,
+          lv2:InputPort ;
+        lv2:index 10 ;
+        lv2:symbol "prefilter" ;
+        lv2:name "Prefilter" ;
+        lv2:default 1 ;
+        lv2:minimum 0 ;
+        lv2:maximum 1 ;
+        lv2:portProperty lv2:toggled
+    ] .

--- a/plugins/lv2/dontfloat_pitch_shift.lv2/manifest.ttl
+++ b/plugins/lv2/dontfloat_pitch_shift.lv2/manifest.ttl
@@ -1,0 +1,7 @@
+@prefix lv2: <http://lv2plug.in/ns/lv2core#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+<https://github.com/ili4yov-ika/DONTFLOAT/plugins/pitch-shift>
+    a lv2:Plugin ;
+    lv2:binary <dontfloat_pitch_shift@LV2_BINARY_EXT@> ;
+    rdfs:seeAlso <dontfloat_pitch_shift.ttl> .

--- a/plugins/lv2/lv2_minimal.h
+++ b/plugins/lv2/lv2_minimal.h
@@ -1,0 +1,35 @@
+#ifndef DONTFLOAT_LV2_MINIMAL_H
+#define DONTFLOAT_LV2_MINIMAL_H
+
+#include <cstdint>
+
+#if defined(_WIN32)
+#define LV2_SYMBOL_EXPORT __declspec(dllexport)
+#else
+#define LV2_SYMBOL_EXPORT __attribute__((visibility("default")))
+#endif
+
+using LV2_Handle = void*;
+
+struct LV2_Feature {
+    const char* URI;
+    void* data;
+};
+
+struct LV2_Descriptor {
+    const char* URI;
+
+    LV2_Handle (*instantiate)(const LV2_Descriptor* descriptor,
+                              double sample_rate,
+                              const char* bundle_path,
+                              const LV2_Feature* const* features);
+
+    void (*connect_port)(LV2_Handle instance, uint32_t port, void* data_location);
+    void (*activate)(LV2_Handle instance);
+    void (*run)(LV2_Handle instance, uint32_t sample_count);
+    void (*deactivate)(LV2_Handle instance);
+    void (*cleanup)(LV2_Handle instance);
+    const void* (*extension_data)(const char* uri);
+};
+
+#endif // DONTFLOAT_LV2_MINIMAL_H

--- a/plugins/lv2/tests/lv2_pitch_shift_smoke_test.cpp
+++ b/plugins/lv2/tests/lv2_pitch_shift_smoke_test.cpp
@@ -1,0 +1,84 @@
+#include "../lv2_minimal.h"
+
+#include <cmath>
+#include <cstring>
+#include <iostream>
+#include <vector>
+
+extern "C" {
+const LV2_Descriptor* lv2_descriptor(uint32_t index);
+}
+
+namespace {
+
+bool isFinite(const std::vector<float>& values)
+{
+    for (float value : values) {
+        if (!std::isfinite(value)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+} // namespace
+
+int main()
+{
+    const LV2_Descriptor* descriptor = lv2_descriptor(0);
+    if (!descriptor || std::strcmp(descriptor->URI, "https://github.com/ili4yov-ika/DONTFLOAT/plugins/pitch-shift") != 0) {
+        std::cerr << "descriptor mismatch\n";
+        return 1;
+    }
+    if (lv2_descriptor(1) != nullptr) {
+        std::cerr << "unexpected second descriptor\n";
+        return 1;
+    }
+
+    LV2_Handle instance = descriptor->instantiate(descriptor, 44100.0, nullptr, nullptr);
+    if (!instance) {
+        std::cerr << "instantiate failed\n";
+        return 1;
+    }
+
+    constexpr uint32_t frames = 256;
+    std::vector<float> inL(frames);
+    std::vector<float> inR(frames);
+    std::vector<float> outL(frames, 0.0f);
+    std::vector<float> outR(frames, 0.0f);
+    for (uint32_t i = 0; i < frames; ++i) {
+        inL[i] = std::sin(float(i) * 0.02f);
+        inR[i] = std::cos(float(i) * 0.05f);
+    }
+
+    float enabled = 1.0f;
+    float pitch = 7.0f;
+    float grainHz = 12.0f;
+    float shape = 0.5f;
+    float jitter = 0.1f;
+    float wet = 0.75f;
+    float prefilter = 1.0f;
+
+    descriptor->connect_port(instance, 0, inL.data());
+    descriptor->connect_port(instance, 1, inR.data());
+    descriptor->connect_port(instance, 2, outL.data());
+    descriptor->connect_port(instance, 3, outR.data());
+    descriptor->connect_port(instance, 4, &enabled);
+    descriptor->connect_port(instance, 5, &pitch);
+    descriptor->connect_port(instance, 6, &grainHz);
+    descriptor->connect_port(instance, 7, &shape);
+    descriptor->connect_port(instance, 8, &jitter);
+    descriptor->connect_port(instance, 9, &wet);
+    descriptor->connect_port(instance, 10, &prefilter);
+
+    descriptor->activate(instance);
+    descriptor->run(instance, frames);
+    descriptor->deactivate(instance);
+    descriptor->cleanup(instance);
+
+    if (!isFinite(outL) || !isFinite(outR)) {
+        std::cerr << "non-finite output\n";
+        return 1;
+    }
+    return 0;
+}

--- a/plugins/vst3/README.md
+++ b/plugins/vst3/README.md
@@ -1,0 +1,75 @@
+# DONTFLOAT VST3
+
+`plugins/vst3` содержит стартовую VST3-обёртку над `plugins/core`.
+Полноценная сборка gated официальным VST3 SDK.
+
+## Цель
+
+Собрать `.vst3` bundle, который можно загрузить в DAW на Windows, macOS и,
+при поддержке хоста, Linux. Плагин должен использовать общий DSP-код, а не
+зависеть от основного GUI-приложения DONTFLOAT.
+
+## Первые кандидаты
+
+### DONTFLOAT Pitch Shift
+- Realtime-friendly кандидат.
+- Основа: `GranularEngine`.
+- Параметры: pitch semitones, grain rate, shape, jitter, wet, prefilter.
+
+### DONTFLOAT Time Stretch
+- Скорее offline/render-time режим.
+- Основа: `TimeStretchProcessor` + `RubberBandOffline`.
+- Требует отдельного дизайна latency, буферизации и поведения при изменении
+  `timeRatio`.
+
+## Bundle layout
+
+Ориентировочно:
+
+```text
+DONTFLOAT Pitch Shift.vst3/
+└── Contents/
+    ├── x86_64-win/
+    │   └── DONTFLOAT Pitch Shift.vst3
+    ├── Resources/
+    └── moduleinfo.json
+```
+
+Для Windows итоговый бинарник может быть `.vst3` DLL внутри bundle. Для macOS
+понадобится стандартный bundle layout, подпись и нотаризация на релизе.
+
+## Интеграция со сборкой
+
+VST3 подключён к `CMakeLists.txt`, но target создаётся только если включён флаг
+и указан путь к SDK:
+
+```cmake
+option(DONTFLOAT_BUILD_PLUGINS "Build DAW plugins" OFF)
+option(DONTFLOAT_BUILD_VST3 "Build VST3 plugin target when SDK is available" OFF)
+set(DONTFLOAT_VST3_SDK_ROOT "" CACHE PATH "Optional path to VST3 SDK")
+```
+
+Сборка при наличии SDK:
+
+```powershell
+cmake -S . -B build/plugins -DDONTFLOAT_BUILD_PLUGINS=ON -DDONTFLOAT_BUILD_VST3=ON -DDONTFLOAT_VST3_SDK_ROOT=C:/path/to/vst3sdk
+cmake --build build/plugins --target dontfloat_pitch_shift_vst3
+```
+
+Текущий файл реализации: `dontfloat_vst3_pitch_shift.cpp`.
+
+## Ограничения
+
+- Не тянуть `MainWindow`, `.ui` файлы и `QApplication` в плагин.
+- Editor UI должен быть отдельным и минимальным; на первом этапе можно
+  использовать generic UI хоста.
+- Все параметры должны иметь стабильные IDs, чтобы проекты DAW открывались
+  после обновлений плагина.
+- Проверить лицензирование VST3 SDK вместе с GPL-кодом проекта до релиза.
+
+## Минимальный proof-of-concept
+
+1. Завершить фабрику/контроллер по официальным шаблонам VST3 SDK.
+2. Добавить параметры в controller и сохранить стабильные IDs.
+3. Проверить bundle в validator из VST3 SDK.
+4. Добавить smoke-тест загрузки bundle в тестовом хосте.

--- a/plugins/vst3/dontfloat_vst3_pitch_shift.cpp
+++ b/plugins/vst3/dontfloat_vst3_pitch_shift.cpp
@@ -1,0 +1,132 @@
+// VST3 starter implementation.
+//
+// This file intentionally depends on the official Steinberg VST3 SDK and is
+// compiled only when DONTFLOAT_BUILD_VST3=ON and DONTFLOAT_VST3_SDK_ROOT is set.
+// The CLAP/LV2 targets are self-contained; VST3 is SDK-gated because the public
+// ABI is not small enough to mirror locally without risking host compatibility.
+
+#include "../core/dontfloat_plugin_core.h"
+
+#include <algorithm>
+
+#if defined(DONTFLOAT_HAS_VST3_SDK)
+#include "public.sdk/source/vst/vstaudioeffect.h"
+#include "pluginterfaces/base/ibstream.h"
+#include "pluginterfaces/vst/ivstparameterchanges.h"
+
+namespace Dontfloat::Vst3 {
+
+using Dontfloat::PluginCore::AudioBufferView;
+using Dontfloat::PluginCore::PitchShiftParams;
+using Dontfloat::PluginCore::PitchShiftProcessor;
+
+enum ParamId : Steinberg::Vst::ParamID {
+    kParamEnabled = 1,
+    kParamPitchSemitones = 2,
+    kParamGrainHz = 3,
+    kParamShape = 4,
+    kParamJitter = 5,
+    kParamWet = 6,
+    kParamPrefilter = 7,
+};
+
+class PitchShiftProcessorVst3 final : public Steinberg::Vst::AudioEffect {
+public:
+    static Steinberg::FUnknown* createInstance(void*)
+    {
+        return static_cast<Steinberg::Vst::IAudioProcessor*>(new PitchShiftProcessorVst3());
+    }
+
+    Steinberg::tresult PLUGIN_API initialize(Steinberg::FUnknown* context) override
+    {
+        const Steinberg::tresult result = AudioEffect::initialize(context);
+        if (result != Steinberg::kResultOk) {
+            return result;
+        }
+
+        addAudioInput(STR16("Stereo In"), Steinberg::Vst::SpeakerArr::kStereo);
+        addAudioOutput(STR16("Stereo Out"), Steinberg::Vst::SpeakerArr::kStereo);
+        return Steinberg::kResultOk;
+    }
+
+    Steinberg::tresult PLUGIN_API setActive(Steinberg::TBool state) override
+    {
+        if (state) {
+            core_.reset();
+        }
+        return AudioEffect::setActive(state);
+    }
+
+    Steinberg::tresult PLUGIN_API setupProcessing(Steinberg::Vst::ProcessSetup& setup) override
+    {
+        core_.prepare(int(setup.sampleRate), int(setup.maxSamplesPerBlock));
+        return AudioEffect::setupProcessing(setup);
+    }
+
+    Steinberg::tresult PLUGIN_API process(Steinberg::Vst::ProcessData& data) override
+    {
+        applyParameterChanges(data.inputParameterChanges);
+
+        if (data.numSamples <= 0 || data.numOutputs <= 0 || data.outputs[0].numChannels <= 0) {
+            return Steinberg::kResultOk;
+        }
+
+        core_.setParams(params_);
+        const float* inputs[2] = {
+            data.numInputs > 0 && data.inputs[0].numChannels > 0 ? data.inputs[0].channelBuffers32[0] : nullptr,
+            data.numInputs > 0 && data.inputs[0].numChannels > 1 ? data.inputs[0].channelBuffers32[1] : nullptr,
+        };
+        float* outputs[2] = {
+            data.outputs[0].numChannels > 0 ? data.outputs[0].channelBuffers32[0] : nullptr,
+            data.outputs[0].numChannels > 1 ? data.outputs[0].channelBuffers32[1] : nullptr,
+        };
+
+        core_.processReplacing(AudioBufferView{
+            inputs,
+            outputs,
+            data.numInputs > 0 ? std::min<int>(data.inputs[0].numChannels, 2) : 0,
+            std::min<int>(data.outputs[0].numChannels, 2),
+            data.numSamples,
+        });
+        return Steinberg::kResultOk;
+    }
+
+private:
+    void applyParameterChanges(Steinberg::Vst::IParameterChanges* changes)
+    {
+        if (!changes) {
+            return;
+        }
+
+        const Steinberg::int32 queueCount = changes->getParameterCount();
+        for (Steinberg::int32 i = 0; i < queueCount; ++i) {
+            Steinberg::Vst::IParamValueQueue* queue = changes->getParameterData(i);
+            if (!queue || queue->getPointCount() <= 0) {
+                continue;
+            }
+
+            Steinberg::int32 sampleOffset = 0;
+            Steinberg::Vst::ParamValue value = 0.0;
+            if (queue->getPoint(queue->getPointCount() - 1, sampleOffset, value) != Steinberg::kResultOk) {
+                continue;
+            }
+
+            switch (queue->getParameterId()) {
+            case kParamEnabled: params_.enabled = value >= 0.5; break;
+            case kParamPitchSemitones: params_.pitchSemitones = float(value * 48.0 - 24.0); break;
+            case kParamGrainHz: params_.grainHz = float(4.0 + value * 36.0); break;
+            case kParamShape: params_.shape = float(value); break;
+            case kParamJitter: params_.jitter = float(value); break;
+            case kParamWet: params_.wet = float(value); break;
+            case kParamPrefilter: params_.prefilter = value >= 0.5; break;
+            default: break;
+            }
+        }
+    }
+
+    PitchShiftProcessor core_;
+    PitchShiftParams params_;
+};
+
+} // namespace Dontfloat::Vst3
+#endif // DONTFLOAT_HAS_VST3_SDK


### PR DESCRIPTION
Добавляет общий plugin core, минимальные CLAP/LV2 обёртки, VST3 SDK hook, smoke-тесты и документацию для будущей DAW-интеграции.