### PR TITLE
fix(pitch): не падать в конце анализа питча.

### DIFF
--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -91,7 +91,6 @@ private slots:
     void togglePitchGrid();
     void analyzeKey();
     void startPitchAnalysis();
-    void onPitchAnalysisFinished();
     void onNotePitchEdited(int noteIndex, float oldPitch, float newPitch);
     void applyPitchCorrection();
     void onNotePreviewRequested(int noteIndex);
@@ -292,18 +291,25 @@ private:
     KeyAnalyzer::PerBarKeyResult lastPerBarKey;
     int editingKeyRegionIndex = -1;
 
-    // Pitch analysis (тональность + ноты) в фоне
+    // Pitch analysis (тональность + ноты) в фоне.
+    // Не используем QFutureWatcher::result(): после длинного анализа
+    // QResultStore/QList::at даёт AV даже для bool (порча store).
+    // Результат передаём через shared_ptr + QueuedConnection.
     struct PitchAnalysisOutcome {
         KeyAnalyzer::AnalysisResult key;
         KeyAnalyzer::PerBarKeyResult perBarKey; // потактовая модуляция (смены тональности)
         QVector<PitchDetector::PitchNote> notes;
     };
-    QFutureWatcher<PitchAnalysisOutcome>* pitchAnalysisWatcher = nullptr;
     std::shared_ptr<std::atomic<int>> pitchAnalysisProgressValue;
     QTimer* pitchAnalysisProgressTimer = nullptr;
     bool pitchAnalysisRunning = false;
+    qint64 pitchAnalysisEpoch = 0; // инвалидирует устаревшее завершение после abort
     QVector<PitchDetector::PitchNote> basePitchNotes; // координаты аудио на момент анализа
     QAction *applyPitchCorrectionAct = nullptr;
+
+    void abortPitchAnalysis();
+    void finishPitchAnalysis(qint64 epoch, bool ok,
+                             const std::shared_ptr<PitchAnalysisOutcome>& pending);
 
     // Прослушивание удерживаемой ноты (зацикленный сегмент, varispeed)
     NotePreviewPlayer* notePreviewPlayer = nullptr;

--- a/src/keyanalyzer.cpp
+++ b/src/keyanalyzer.cpp
@@ -118,12 +118,16 @@ KeyAnalyzer::AnalysisResult KeyAnalyzer::analyzeKeyUsingQM(const QVector<float>&
         QVector<double> doubleSamples = convertToDouble(samples);
         
         // Обрабатываем аудио по кадрам
-        int frameSize = keyDetector.getBlockSize();
-        int hopSize = keyDetector.getHopSize();
+        const int frameSize = keyDetector.getBlockSize();
+        const int hopSize = keyDetector.getHopSize();
+        if (frameSize <= 0 || hopSize <= 0 || doubleSamples.size() < frameSize) {
+            qDebug() << "GetKeyMode: invalid frame/hop size or too short audio";
+            return result;
+        }
         
         QVector<QVector<double>> chromaFrames;
         
-        for (int i = 0; i < doubleSamples.size() - frameSize; i += hopSize) {
+        for (int i = 0; i <= doubleSamples.size() - frameSize; i += hopSize) {
             QVector<double> frame(doubleSamples.begin() + i, 
                                  doubleSamples.begin() + i + frameSize);
             
@@ -502,6 +506,9 @@ KeyAnalyzer::KeyInfo KeyAnalyzer::dominantModulationKey(const PerBarKeyResult& p
             continue;
         }
         const int idx = int(b.key.key);
+        if (idx < 0 || idx >= counts.size()) {
+            continue;
+        }
         ++counts[idx];
         strengthSum[idx] += b.key.strength;
         confidenceSum[idx] += b.key.confidence;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -39,6 +39,7 @@
 #include <QtCore/QDir>
 #include <QtCore/QtGlobal>
 #include <QtCore/QDebug>
+#include <QtCore/QPointer>
 #include <QtCore/QSignalBlocker>
 #include <QtCore/QEventLoop>
 #include <QtConcurrent/QtConcurrent>
@@ -1747,11 +1748,11 @@ void MainWindow::resetAudioState()
 
     // Сбрасываем результаты анализа нот прошлого файла
     stopNotePreview();
+    abortPitchAnalysis();
     basePitchNotes.clear();
     if (pitchGridWidget) {
         pitchGridWidget->clearNotes();
     }
-    setPitchAnalysisUiRunning(false);
 
     hidePitchGridAnalyzeOverlay();
 
@@ -2581,6 +2582,16 @@ void MainWindow::onPitchGridAnalyzeClicked()
     startPitchAnalysis();
 }
 
+void MainWindow::abortPitchAnalysis()
+{
+    ++pitchAnalysisEpoch;
+    pitchAnalysisRunning = false;
+    if (pitchAnalysisProgressTimer) {
+        pitchAnalysisProgressTimer->stop();
+    }
+    setPitchAnalysisUiRunning(false);
+}
+
 void MainWindow::setPitchAnalysisUiRunning(bool running)
 {
     if (pitchGridAnalyzeButton) {
@@ -2616,6 +2627,7 @@ void MainWindow::startPitchAnalysis()
     barGrid.beatsPerBar = waveformView->getBeatsPerBar();
     barGrid.gridStartSample = waveformView->getGridStartSample();
 
+    const qint64 epoch = ++pitchAnalysisEpoch;
     pitchAnalysisRunning = true;
     setPitchAnalysisUiRunning(true);
     statusBar()->showMessage(tr("Analyzing key and notes..."), 0);
@@ -2632,48 +2644,76 @@ void MainWindow::startPitchAnalysis()
     }
     pitchAnalysisProgressTimer->start();
 
-    if (!pitchAnalysisWatcher) {
-        pitchAnalysisWatcher = new QFutureWatcher<PitchAnalysisOutcome>(this);
-        connect(pitchAnalysisWatcher, &QFutureWatcher<PitchAnalysisOutcome>::finished,
-                this, &MainWindow::onPitchAnalysisFinished);
-    }
-
+    auto pending = std::make_shared<PitchAnalysisOutcome>();
     std::shared_ptr<std::atomic<int>> progress = pitchAnalysisProgressValue;
-    pitchAnalysisWatcher->setFuture(QtConcurrent::run([mono, sampleRate, progress, barGrid]() {
-        PitchAnalysisOutcome outcome;
-        progress->store(2);
-        outcome.key = KeyAnalyzer::analyzeKey(mono, sampleRate);
-        progress->store(8);
-        outcome.perBarKey = KeyAnalyzer::analyzeKeyPerBar(mono, sampleRate, barGrid);
-        progress->store(15);
-        outcome.notes = PitchDetector::detectNotes(
-            mono, sampleRate, PitchDetector::Options(),
-            [progress](int pct) { progress->store(15 + pct * 85 / 100); });
-        progress->store(100);
-        return outcome;
-    }));
+    // QPointer: окно могли закрыть, пока крутится пул потоков.
+    const QPointer<MainWindow> self(this);
+
+    (void)QtConcurrent::run([self, epoch, mono, sampleRate, progress, barGrid, pending]() {
+        bool ok = false;
+        try {
+            progress->store(2);
+            pending->perBarKey = KeyAnalyzer::analyzeKeyPerBar(mono, sampleRate, barGrid);
+            progress->store(12);
+            pending->key.primaryKey = pending->perBarKey.primaryKey;
+            pending->key.overallConfidence = pending->perBarKey.primaryKey.confidence;
+            pending->key.hasKeyChange = pending->perBarKey.hasModulation;
+            if (pending->perBarKey.hasModulation) {
+                pending->key.secondaryKey =
+                    KeyAnalyzer::dominantModulationKey(
+                        pending->perBarKey, pending->perBarKey.primaryKey.key);
+            }
+            progress->store(15);
+            pending->notes = PitchDetector::detectNotes(
+                mono, sampleRate, PitchDetector::Options(),
+                [progress](int pct) { progress->store(15 + pct * 85 / 100); });
+            progress->store(100);
+            ok = true;
+        } catch (const std::exception& e) {
+            qWarning() << "Pitch analysis failed:" << e.what();
+        } catch (...) {
+            qWarning() << "Pitch analysis failed with unknown exception";
+        }
+
+        if (!self) {
+            return;
+        }
+        // Без QFutureWatcher::result() — только QueuedConnection в UI-поток.
+        QMetaObject::invokeMethod(self, [self, epoch, ok, pending]() {
+            if (!self) {
+                return;
+            }
+            self->finishPitchAnalysis(epoch, ok, pending);
+        }, Qt::QueuedConnection);
+    });
 }
 
-void MainWindow::onPitchAnalysisFinished()
+void MainWindow::finishPitchAnalysis(qint64 epoch, bool ok,
+                                     const std::shared_ptr<PitchAnalysisOutcome>& pending)
 {
+    if (epoch != pitchAnalysisEpoch) {
+        return;
+    }
+
     pitchAnalysisRunning = false;
     if (pitchAnalysisProgressTimer) {
         pitchAnalysisProgressTimer->stop();
     }
-    if (!pitchAnalysisWatcher) {
+
+    if (!ok || !pending) {
+        setPitchAnalysisUiRunning(false);
+        statusBar()->showMessage(tr("Analysis failed"), 3000);
         return;
     }
 
-    const PitchAnalysisOutcome outcome = pitchAnalysisWatcher->result();
-
-    applyPerBarKeyResult(outcome.perBarKey, outcome.key);
+    applyPerBarKeyResult(pending->perBarKey, pending->key);
 
     QString keysText = currentKey;
     if (!currentKey2.isEmpty()) {
         keysText += QStringLiteral(" / ") + currentKey2;
     }
 
-    basePitchNotes = outcome.notes;
+    basePitchNotes = pending->notes;
     refreshPitchGridNotes();
 
     setPitchAnalysisUiRunning(false);

--- a/thirdparty/qm-dsp/dsp/keydetection/GetKeyMode.cpp
+++ b/thirdparty/qm-dsp/dsp/keydetection/GetKeyMode.cpp
@@ -101,6 +101,19 @@ GetKeyMode::GetKeyMode(Config config) :
         (m_hpcpAverage * chromaConfig.FS / m_chromaFrameSize);
     m_medianWinSize = (int)ceil
         (m_medianAverage * chromaConfig.FS / m_chromaFrameSize);
+    // ceil(...) can be 0 for extreme frame sizes → process() writes index -1 / OOB.
+    if (m_chromaFrameSize <= 0) {
+        m_chromaFrameSize = 1;
+    }
+    if (m_chromaHopSize <= 0) {
+        m_chromaHopSize = 1;
+    }
+    if (m_chromaBufferSize < 1) {
+        m_chromaBufferSize = 1;
+    }
+    if (m_medianWinSize < 1) {
+        m_medianWinSize = 1;
+    }
     
     // Reset counters
     m_bufferIndex = 0;
@@ -194,6 +207,12 @@ int GetKeyMode::process(double *pcmData)
 {
     int key;
     int j, k;
+
+    if (!pcmData || !m_decimator || !m_chroma || !m_chromaBuffer
+        || !m_medianFilterBuffer || !m_sortedBuffer
+        || m_chromaBufferSize < 1 || m_medianWinSize < 1) {
+        return 0;
+    }
 
     m_decimator->process(pcmData, m_decimatedBuffer);
 


### PR DESCRIPTION
Убрать QFutureWatcher::result() (AV в QList::at после длинного анализа), передавать итог через shared_ptr + QueuedConnection; укрепить GetKeyMode.