### PR TITLE
Embeddable CLAP plugin editor on Linux (Melodyne-style DAW GUI)

### DIFF
--- a/plugins/clap/clap_minimal.h
+++ b/plugins/clap/clap_minimal.h
@@ -13,8 +13,12 @@
 #define CLAP_EXT_PARAMS "clap.params"
 #define CLAP_EXT_AUDIO_PORTS "clap.audio-ports"
 #define CLAP_EXT_GUI "clap.gui"
+#define CLAP_EXT_TIMER_SUPPORT "clap.timer-support"
 #define CLAP_PORT_STEREO "stereo"
 #define CLAP_WINDOW_API_WIN32 "win32"
+#define CLAP_WINDOW_API_COCOA "cocoa"
+#define CLAP_WINDOW_API_X11 "x11"
+#define CLAP_WINDOW_API_WAYLAND "wayland"
 
 #define CLAP_CORE_EVENT_SPACE_ID 0
 #define CLAP_EVENT_PARAM_VALUE 5
@@ -198,6 +202,17 @@ struct clap_window_t {
         uintptr_t x11;
         void* ptr;
     };
+};
+
+// clap.timer-support — lets a plugin ask the host to call it back periodically.
+// Used to pump the Qt event loop when the host is not Qt-based.
+struct clap_host_timer_support_t {
+    bool (*register_timer)(const clap_host_t* host, uint32_t period_ms, clap_id* timer_id);
+    bool (*unregister_timer)(const clap_host_t* host, clap_id timer_id);
+};
+
+struct clap_plugin_timer_support_t {
+    void (*on_timer)(const clap_plugin_t* plugin, clap_id timer_id);
 };
 
 struct clap_plugin_gui_t {

--- a/plugins/clap/dontfloat_clap_plugin_impl.cpp
+++ b/plugins/clap/dontfloat_clap_plugin_impl.cpp
@@ -4,7 +4,10 @@
 #include "../ui/dontfloat_plugin_editor_shell.h"
 #include "../ui/dontfloat_qt_hosting.h"
 
+#include <QApplication>
+#include <QEventLoop>
 #include <QString>
+#include <QWindow>
 
 #include <algorithm>
 #include <cstring>
@@ -35,9 +38,32 @@ struct ClapPluginInstance {
     const clap_host_t* host = nullptr;
     TrackToolSession session;
     std::unique_ptr<DontfloatPluginEditorShell> editor;
+    std::unique_ptr<QWindow> foreignParent; // host window wrapper (X11 embedding)
     uint32_t editorWidth = kEditorWidth;
     uint32_t editorHeight = kEditorHeight;
+    clap_id guiTimerId = 0;
+    bool guiTimerRegistered = false;
 };
+
+// Pump the Qt event loop from the host timer so the editor stays responsive
+// inside non-Qt DAW hosts (Reaper, Bitwig, Ardour, …).
+void pumpQtEvents()
+{
+    if (QApplication* app = qApp) {
+        app->sendPostedEvents();
+        app->processEvents(QEventLoop::AllEvents, 8);
+        app->sendPostedEvents(nullptr, QEvent::DeferredDelete);
+    }
+}
+
+const clap_host_timer_support_t* hostTimerSupport(ClapPluginInstance* s)
+{
+    if (!s || !s->host || !s->host->get_extension) {
+        return nullptr;
+    }
+    return static_cast<const clap_host_timer_support_t*>(
+        s->host->get_extension(s->host, CLAP_EXT_TIMER_SUPPORT));
+}
 
 const char* const kFeatures[] = {
     "audio-effect",
@@ -154,26 +180,31 @@ bool guiIsApiSupported(const clap_plugin_t*, const char* api, bool isFloating)
 {
 #if defined(_WIN32)
     return api && std::strcmp(api, CLAP_WINDOW_API_WIN32) == 0 && !isFloating;
-#else
+#elif defined(__APPLE__)
     (void)api;
     (void)isFloating;
-    return false;
+    return false; // Cocoa embedding not implemented yet
+#else
+    // Linux: embed into the host's X11 window.
+    return api && std::strcmp(api, CLAP_WINDOW_API_X11) == 0 && !isFloating;
 #endif
 }
 
 bool guiGetPreferredApi(const clap_plugin_t*, const char** api, bool* isFloating)
 {
-#if defined(_WIN32)
     if (!api || !isFloating) {
         return false;
     }
+#if defined(_WIN32)
     *api = CLAP_WINDOW_API_WIN32;
     *isFloating = false;
     return true;
-#else
-    (void)api;
-    (void)isFloating;
+#elif defined(__APPLE__)
     return false;
+#else
+    *api = CLAP_WINDOW_API_X11;
+    *isFloating = false;
+    return true;
 #endif
 }
 
@@ -190,16 +221,32 @@ bool guiCreate(const clap_plugin_t* plugin, const char* api, bool isFloating)
     s->editor->setWindowTitle(QString::fromUtf8(desc().clapName));
     s->editor->resize(int(s->editorWidth), int(s->editorHeight));
     s->editor->setAttribute(Qt::WA_NativeWindow, true);
+
+    // Ask the host to tick us so the Qt event loop keeps running in non-Qt DAWs.
+    if (const clap_host_timer_support_t* ts = hostTimerSupport(s)) {
+        if (ts->register_timer && ts->register_timer(s->host, 16, &s->guiTimerId)) {
+            s->guiTimerRegistered = true;
+        }
+    }
     return true;
 }
 
 void guiDestroy(const clap_plugin_t* plugin)
 {
     if (ClapPluginInstance* s = self(plugin)) {
+        if (s->guiTimerRegistered) {
+            if (const clap_host_timer_support_t* ts = hostTimerSupport(s)) {
+                if (ts->unregister_timer) {
+                    ts->unregister_timer(s->host, s->guiTimerId);
+                }
+            }
+            s->guiTimerRegistered = false;
+        }
         if (s->editor) {
             s->editor->hide();
         }
         s->editor.reset();
+        s->foreignParent.reset();
     }
 }
 
@@ -258,10 +305,34 @@ bool guiSetParent(const clap_plugin_t* plugin, const clap_window_t* window)
     SetWindowLongPtr(child, GWL_STYLE, WS_CHILD | WS_VISIBLE);
     MoveWindow(child, 0, 0, int(s->editorWidth), int(s->editorHeight), TRUE);
     return true;
-#else
+#elif defined(__APPLE__)
     (void)plugin;
     (void)window;
     return false;
+#else
+    // Linux/X11: reparent the editor's native window under the host window.
+    ClapPluginInstance* s = self(plugin);
+    if (!s || !s->editor || !window) {
+        return false;
+    }
+    if (window->api && std::strcmp(window->api, CLAP_WINDOW_API_X11) != 0) {
+        return false;
+    }
+
+    (void)s->editor->winId(); // force creation of the native X11 window
+    QWindow* childWindow = s->editor->windowHandle();
+    if (!childWindow) {
+        return false;
+    }
+    QWindow* parentWindow = QWindow::fromWinId(static_cast<WId>(window->x11));
+    if (!parentWindow) {
+        return false;
+    }
+    s->foreignParent.reset(parentWindow);
+    childWindow->setParent(parentWindow);
+    s->editor->move(0, 0);
+    s->editor->resize(int(s->editorWidth), int(s->editorHeight));
+    return true;
 #endif
 }
 
@@ -310,6 +381,17 @@ const clap_plugin_gui_t kGuiExtension = {
     guiHide,
 };
 
+void pluginOnTimer(const clap_plugin_t* plugin, clap_id timerId)
+{
+    ClapPluginInstance* s = self(plugin);
+    if (!s || !s->guiTimerRegistered || timerId != s->guiTimerId) {
+        return;
+    }
+    pumpQtEvents();
+}
+
+const clap_plugin_timer_support_t kTimerSupportExtension = { pluginOnTimer };
+
 const void* pluginGetExtension(const clap_plugin_t*, const char* id)
 {
     if (id && std::strcmp(id, CLAP_EXT_AUDIO_PORTS) == 0) {
@@ -317,6 +399,9 @@ const void* pluginGetExtension(const clap_plugin_t*, const char* id)
     }
     if (id && std::strcmp(id, CLAP_EXT_GUI) == 0) {
         return &kGuiExtension;
+    }
+    if (id && std::strcmp(id, CLAP_EXT_TIMER_SUPPORT) == 0) {
+        return &kTimerSupportExtension;
     }
     return nullptr;
 }

--- a/plugins/core/dontfloat_plugin_core.cpp
+++ b/plugins/core/dontfloat_plugin_core.cpp
@@ -110,8 +110,13 @@ TrackToolStatus TrackToolSession::appendHostFrames(const float* const* inputs,
         return TrackToolStatus::InvalidAudioInfo;
     }
 
-    if (audioBuffer_.sampleRate <= 0) {
-        audioBuffer_.sampleRate = audioInfo_.sampleRate > 0 ? audioInfo_.sampleRate : 44100;
+    // Host-captured audio must use the sample rate the plugin was activated with,
+    // not the TrackAudioBuffer default (44100). Otherwise analysis (BPM/pitch)
+    // runs at the wrong rate inside a DAW.
+    if (audioInfo_.sampleRate > 0) {
+        audioBuffer_.sampleRate = audioInfo_.sampleRate;
+    } else if (audioBuffer_.sampleRate <= 0) {
+        audioBuffer_.sampleRate = 44100;
     }
     audioBuffer_.channelCount = std::max(audioBuffer_.channelCount, channelCount);
 

--- a/tools/mini_daw/README.md
+++ b/tools/mini_daw/README.md
@@ -35,9 +35,15 @@ QT_QPA_PLATFORM=offscreen ./mini_daw_clap_full --seconds 4 --no-output
 QT_QPA_PLATFORM=offscreen ./mini_daw_lv2_scratch \
     --input tests/midi/test_1.wav --output out.wav
 
-# process the whole file through the Pitcher CLAP plugin
-QT_QPA_PLATFORM=offscreen ./mini_daw_clap_pitcher --full --no-output
+# CLAP: open the plugin editor embedded in a host window (needs a display),
+# just like a DAW — the Pitcher shows the piano roll and an interactive Analyze
+QT_QPA_PLATFORM=xcb ./mini_daw_clap_pitcher --gui --seconds 5
 ```
+
+The `--gui` flag (CLAP hosts only) acts as a tiny DAW: it creates a host window,
+loads the plugin, feeds it `test_1.wav`, then embeds the plugin editor via the
+CLAP `clap.gui` **X11** extension and runs it — proving the plugin UI shows and
+is interactive (Melodyne-style) inside a host.
 
 ### Options
 
@@ -48,6 +54,7 @@ QT_QPA_PLATFORM=offscreen ./mini_daw_clap_pitcher --full --no-output
 | `--block <n>` | `512` | host processing block size (frames) |
 | `--seconds <s>` | `8` | cap processed length (`--full` = whole file) |
 | `--no-output` | write | skip writing the output WAV |
+| `--gui` / `--headless` | headless | CLAP only: embed & show the plugin editor |
 
 > Note: these hosts need a Qt platform plugin; run headless with
 > `QT_QPA_PLATFORM=offscreen`.

--- a/tools/mini_daw/clap_mini_daw.cpp
+++ b/tools/mini_daw/clap_mini_daw.cpp
@@ -8,6 +8,9 @@
 #include "clap_minimal.h"
 #include "mini_daw_host.h"
 
+#include <QtGui/QWindow>
+#include <QtWidgets/QWidget>
+
 #include <cstring>
 #include <iostream>
 #include <vector>
@@ -17,6 +20,122 @@ extern const clap_plugin_entry_t clap_entry;
 }
 
 namespace {
+
+const void* hostGetExtension(const clap_host_t*, const char*)
+{
+    // Our host is Qt-based and runs its own event loop, so we do not need to
+    // provide clap.timer-support; the plugin's timer registration fails
+    // gracefully and the editor is pumped by the host QApplication loop.
+    return nullptr;
+}
+
+// Feed the whole file into the plugin so its session captures the audio, then
+// create the plugin editor via the clap.gui X11 extension, reparent it into a
+// host window, and run the Qt event loop — exactly how a DAW hosts the plugin.
+int runClapGuiHost(QApplication& app, const MiniDaw::LoadedAudio& a, const MiniDaw::Options& o)
+{
+    if (!clap_entry.init("dontfloat.clap")) {
+        std::cerr << " [clap] clap_entry.init failed\n";
+        return 1;
+    }
+    const auto* factory = static_cast<const clap_plugin_factory_t*>(
+        clap_entry.get_factory(CLAP_PLUGIN_FACTORY_ID));
+    if (!factory || factory->get_plugin_count(factory) < 1) {
+        std::cerr << " [clap] factory unavailable\n";
+        return 1;
+    }
+    const clap_plugin_descriptor_t* descriptor = factory->get_plugin_descriptor(factory, 0);
+
+    clap_host_t host {};
+    host.clap_version = CLAP_VERSION_INIT;
+    host.name = "DONTFLOAT mini-DAW";
+    host.get_extension = hostGetExtension;
+
+    const clap_plugin_t* plugin = factory->create_plugin(factory, &host, descriptor->id);
+    if (!plugin || !plugin->init(plugin)) {
+        std::cerr << " [clap] create/init failed\n";
+        return 1;
+    }
+
+    const uint32_t block = static_cast<uint32_t>(o.blockSize);
+    plugin->activate(plugin, double(a.sampleRate), 1, block);
+    plugin->start_processing(plugin);
+
+    // Stream the file so the plugin session captures the audio for the editor.
+    std::vector<float> inL(block), inR(block), oL(block), oR(block);
+    float* inPtr[] = { inL.data(), inR.data() };
+    float* outPtr[] = { oL.data(), oR.data() };
+    clap_audio_buffer_t input {};
+    input.data32 = inPtr;
+    input.channel_count = 2;
+    clap_audio_buffer_t output {};
+    output.data32 = outPtr;
+    output.channel_count = 2;
+    clap_process_t process {};
+    process.audio_inputs = &input;
+    process.audio_outputs = &output;
+    for (long long pos = 0; pos < a.frames;) {
+        const uint32_t n = static_cast<uint32_t>(std::min<long long>(block, a.frames - pos));
+        for (uint32_t i = 0; i < n; ++i) {
+            inL[i] = a.left[pos + i];
+            inR[i] = a.right[pos + i];
+        }
+        process.frames_count = n;
+        process.steady_time = pos;
+        plugin->process(plugin, &process);
+        pos += n;
+    }
+    plugin->stop_processing(plugin);
+    std::printf(" [clap] session filled with %lld frames; opening editor…\n", a.frames);
+
+    const auto* gui = static_cast<const clap_plugin_gui_t*>(
+        plugin->get_extension(plugin, CLAP_EXT_GUI));
+    if (!gui) {
+        std::cerr << " [clap] gui extension unavailable\n";
+        return 1;
+    }
+    const char* api = nullptr;
+    bool floating = false;
+    if (!gui->get_preferred_api(plugin, &api, &floating) || !api) {
+        std::cerr << " [clap] no preferred GUI api (no display / unsupported platform)\n";
+        return 1;
+    }
+    if (!gui->is_api_supported(plugin, api, false) || !gui->create(plugin, api, false)) {
+        std::cerr << " [clap] gui create failed for api " << api << "\n";
+        return 1;
+    }
+    uint32_t w = 960;
+    uint32_t h = 640;
+    gui->get_size(plugin, &w, &h);
+
+    // Host window that the DAW would provide.
+    auto* hostWindow = new QWidget;
+    hostWindow->setWindowTitle(
+        QStringLiteral("DONTFLOAT mini-DAW [CLAP host] — %1").arg(QString::fromUtf8(MiniDaw::productName())));
+    hostWindow->setAttribute(Qt::WA_NativeWindow, true);
+    hostWindow->resize(int(w), int(h));
+    hostWindow->show();
+    (void)hostWindow->winId();
+
+    clap_window_t window {};
+    window.api = api;
+    window.x11 = static_cast<uintptr_t>(hostWindow->winId());
+    if (!gui->set_parent(plugin, &window)) {
+        std::cerr << " [clap] gui set_parent failed for api " << api << "\n";
+    }
+    gui->set_size(plugin, w, h);
+    gui->show(plugin);
+    std::printf(" [clap] editor embedded (api=%s, %ux%u). Close the window to exit.\n", api, w, h);
+
+    const int rc = app.exec();
+
+    gui->hide(plugin);
+    gui->destroy(plugin);
+    plugin->deactivate(plugin);
+    plugin->destroy(plugin);
+    clap_entry.deinit();
+    return rc;
+}
 
 // Instantiate the CLAP plugin and stream the file through process() in blocks.
 int runClapEngine(const MiniDaw::LoadedAudio& a, const MiniDaw::Options& o,
@@ -129,6 +248,10 @@ int main(int argc, char** argv)
                      options.input.toLocal8Bit().constData(),
                      audio.error.toLocal8Bit().constData());
         return 2;
+    }
+
+    if (options.gui) {
+        return runClapGuiHost(app, audio, options);
     }
 
     std::vector<float> outL, outR;

--- a/tools/mini_daw/mini_daw_host.h
+++ b/tools/mini_daw/mini_daw_host.h
@@ -37,6 +37,7 @@ struct Options {
     int blockSize = 512;       // host processing block size (frames)
     double maxSeconds = 8.0;   // cap processed length (<= 0 => whole file)
     bool writeOutput = true;   // write the processed output WAV
+    bool gui = false;          // embed & show the plugin editor (CLAP X11 host)
 };
 
 inline const char* productName()
@@ -64,8 +65,11 @@ inline Options parseArgs(int argc, char** argv, const char* formatTag)
             o.maxSeconds = 0.0;
         } else if (a == QLatin1String("--no-output")) {
             o.writeOutput = false;
+        } else if (a == QLatin1String("--gui")) {
+            o.gui = true;
+        } else if (a == QLatin1String("--headless")) {
+            o.gui = false;
         }
-        // --headless is accepted for compatibility (this host is always headless).
     }
     if (o.output.isEmpty()) {
         o.output = QStringLiteral("mini_daw_%1_%2_out.wav")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Makes the DONTFLOAT plugins show their editor and be usable inside DAWs on Linux, like Melodyne. Previously the CLAP GUI was Win32-only (returned `false` for X11), so no interface appeared in Linux DAWs.

## Changes

- **CLAP X11 GUI** (`plugins/clap/dontfloat_clap_plugin_impl.cpp`): implement `clap.gui` for X11 — `is_api_supported`/`get_preferred_api`/`set_parent` now embed the editor into the host window via `QWindow::fromWinId()` + `windowHandle()->setParent()`. Win32 path unchanged.
- **Event pumping** (`clap.timer-support`): register a 16 ms host timer and pump the Qt event loop in `on_timer`, so the editor stays responsive inside non-Qt hosts (Reaper/Bitwig/Ardour). Exposed via `get_extension`.
- **`clap_minimal.h`**: add the X11/Cocoa/Wayland window-API names and the `clap.timer-support` host/plugin extension structs.
- **Core sample-rate fix** (`plugins/core/dontfloat_plugin_core.cpp`): `appendHostFrames` now captures host audio at the activated sample rate instead of the `TrackAudioBuffer` default (44100), so in-DAW BPM/pitch analysis runs at the correct rate.
- **mini-DAW `--gui`** (`tools/mini_daw/clap_mini_daw.cpp`): `mini_daw_clap_*` gains a `--gui` mode that acts as a tiny CLAP DAW host — creates a host window, loads `test_1.wav`, feeds it to the plugin, then embeds the plugin editor via `clap.gui` X11 and runs it.

LV2 already exposes an X11 UI with idle-based event pumping. VST3 GUI still requires the proprietary Steinberg SDK.

## Verification

- Ran `mini_daw_clap_pitcher --gui` on Linux (X11): the **Pitcher** editor embeds into the host window and renders the piano roll (CPU idle — no spin). Clicking **Analyze** detects **31 notes** and shows keys **F# Major / C Minor** — interactive, Melodyne-style.
- After the sample-rate fix the editor reports the correct **192000 Hz** for `test_1.wav`.
- Full build clean (plugins + mini-DAWs + main app). **Main program `DONTFLOAT` builds** and the full suite is **29/29 passing** (`CI=1 GITHUB_ACTIONS=1 QT_QPA_PLATFORM=offscreen ctest`).

[clap_pitcher_plugin_in_daw_host.mp4](https://cursor.com/agents/bc-f69c2860-9d39-49b0-b7fe-89a1dc9d2cab/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fclap_pitcher_plugin_in_daw_host.mp4)
[CLAP Pitcher editor embedded in host, notes detected (F# Major / C Minor, 31 notes)](https://cursor.com/agents/bc-f69c2860-9d39-49b0-b7fe-89a1dc9d2cab/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fclap_pitcher_analysis_in_host.webp)
[CLAP Pitcher editor embedded in host with test_1.wav loaded (192000 Hz)](https://cursor.com/agents/bc-f69c2860-9d39-49b0-b7fe-89a1dc9d2cab/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fclap_pitcher_embedded_loaded.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f69c2860-9d39-49b0-b7fe-89a1dc9d2cab?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f69c2860-9d39-49b0-b7fe-89a1dc9d2cab&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

